### PR TITLE
Quickfix Hunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Visual Git Plugin for Neovim to enhance your git experience.
 
 ![blames](https://user-images.githubusercontent.com/25164326/117505703-7d578980-af52-11eb-82c8-22ea0c4bbd2a.gif)
 
+- [x] Quickfix your hunks
+
+![hunks_quickfix](https://user-images.githubusercontent.com/25164326/118189592-fc940400-b40f-11eb-9741-75bb81d5ed64.gif)
+
 
 ## Prerequisites
 - [Git](https://git-scm.com/)

--- a/lua/vgit/git.lua
+++ b/lua/vgit/git.lua
@@ -35,18 +35,6 @@ local function parse_hunk_header(line)
     return origin, current
 end
 
-local function split_by(str, sep)
-    if sep == nil then
-        sep = "%s"
-    end
-    local chunks = {}
-    local match = string.gmatch(str, '([^' .. sep .. ']+)')
-    for s in match do
-        table.insert(chunks, s)
-    end
-    return chunks
-end
-
 local M = {}
 
 local constants = {
@@ -86,7 +74,7 @@ M.config = function()
             '--list',
         },
         on_stdout = function(_, line)
-            local line_chunks = split_by(line, '=')
+            local line_chunks = vim.split(line, '=')
             config[line_chunks[1]] = line_chunks[2]
         end,
         on_stderr = function(err, line)
@@ -108,6 +96,7 @@ end
 M.create_hunk = function(header)
     local origin, current = parse_hunk_header(header)
     local hunk = {
+        header = header,
         start = current[1],
         finish = current[1] + current[2] - 1,
         type = nil,
@@ -169,7 +158,7 @@ end
 
 M.create_blame = function(info)
     local function split_by_whitespace(str)
-        return split_by(str, ' ')
+        return vim.split(str, ' ')
     end
     local hash_info = split_by_whitespace(info[1])
     local author_mail_info = split_by_whitespace(info[3])
@@ -375,6 +364,34 @@ M.buffer_reset = function(filename)
         return err_result
     end
     return nil
+end
+
+M.ls = function()
+    local filenames = {}
+    local err_result = ''
+    local job = Job:new({
+        command = 'git',
+        args = {
+            'diff',
+            '--name-only',
+        },
+        on_stdout = function(_, line)
+            table.insert(filenames, line)
+        end,
+        on_stderr = function(err, line)
+            if err then
+                err_result = err_result .. err
+            elseif line then
+                err_result = err_result .. line
+            end
+        end,
+    })
+    job:sync()
+    job:wait()
+    if err_result ~= '' then
+        return err_result, nil
+    end
+    return nil, filenames
 end
 
 return M

--- a/lua/vgit/git.lua
+++ b/lua/vgit/git.lua
@@ -60,7 +60,6 @@ M.tear_down = function()
 end
 
 M.get_state = function()
-    -- TODO: Directly returning object in memory (Pros: No computation wasted for cloning, Cons: Mutable object)
     return state
 end
 

--- a/lua/vgit/init.lua
+++ b/lua/vgit/init.lua
@@ -77,7 +77,7 @@ M._close_preview_window = function(...)
     local args = {...}
     for _, win in ipairs(args) do
         if vim.api.nvim_win_is_valid(win) then
-            vim.api.nvim_win_close(win, false)
+            vim.api.nvim_win_close(win, true)
         end
     end
 end

--- a/lua/vgit/init.lua
+++ b/lua/vgit/init.lua
@@ -218,7 +218,7 @@ M.hunk_up = function(buf, win)
             break
         end
     end
-    if new_lnum then
+    if new_lnum and lnum ~= new_lnum then
         vim.api.nvim_win_set_cursor(win, { new_lnum, 0 })
         vim.api.nvim_command('norm! zz')
     else
@@ -267,6 +267,28 @@ M.hunk_reset = function(buf, win)
             ui.hide_hunk_signs(buf)
             ui.show_hunk_signs(buf, hunks)
         end
+    end
+end
+
+M.hunks_quickfix = function()
+    local err, filenames = git.ls()
+    if not err then
+        local qf_entries = {}
+        for _, filename in ipairs(filenames) do
+            local hunks_err, hunks = git.buffer_hunks(filename)
+            if not hunks_err then
+                for _, hunk in ipairs(hunks) do
+                    table.insert(qf_entries, {
+                        text = hunk.header,
+                        filename = filename,
+                        lnum = hunk.start,
+                        col = 0,
+                    })
+                end
+            end
+        end
+        vim.fn.setqflist(qf_entries, 'r')
+        vim.api.nvim_command('copen')
     end
 end
 

--- a/lua/vgit/init.lua
+++ b/lua/vgit/init.lua
@@ -222,7 +222,7 @@ M.hunk_up = function(buf, win)
         vim.api.nvim_win_set_cursor(win, { new_lnum, 0 })
         vim.api.nvim_command('norm! zz')
     else
-        vim.api.nvim_win_set_cursor(win, { hunks[#hunks].start, 0 })
+        vim.api.nvim_win_set_cursor(win, { hunks[#hunks].finish, 0 })
         vim.api.nvim_command('norm! zz')
     end
 end

--- a/lua/vgit/ui.lua
+++ b/lua/vgit/ui.lua
@@ -395,13 +395,16 @@ M.show_hunk = function(hunk, filetype)
     vim.api.nvim_win_set_option(win_id, 'wrap', false)
     vim.api.nvim_win_set_option(win_id, 'signcolumn', 'yes')
     local bufs = vim.api.nvim_list_bufs()
-    vim.api.nvim_buf_set_keymap(
-        buf,
-        'n',
-        '<C-c>',
-        string.format(':lua require("vgit")._close_preview_window(%s)<CR>', win_id),
-        { silent = true }
-    )
+    local mappings = {'<esc>', '<C-c>'}
+    for _, mapping in ipairs(mappings) do
+        vim.api.nvim_buf_set_keymap(
+            buf,
+            'n',
+            mapping,
+            string.format(':lua require("vgit")._close_preview_window(%s)<CR>', win_id),
+            { silent = true }
+        )
+    end
     for _, current_buf in ipairs(bufs) do
         vim.api.nvim_command(
             string.format(
@@ -432,9 +435,6 @@ M.show_diff = function(cwd_lines, origin_lines, lnum_changes, filetype)
         }
     }
     for _, window in pairs(windows) do
-        vim.api.nvim_buf_set_option(window.buf, 'bufhidden', 'wipe')
-        vim.api.nvim_buf_set_option(window.buf, 'buftype', 'nofile')
-        vim.api.nvim_buf_set_option(window.buf, 'buflisted', false)
         vim.api.nvim_buf_set_lines(window.buf, 0, -1, false, window.lines)
         highlight_with_ts(window.buf, filetype)
     end
@@ -465,7 +465,6 @@ M.show_diff = function(cwd_lines, origin_lines, lnum_changes, filetype)
         border = state.diff.window.border,
         row = math.ceil((global_height - height) / 2 - 1),
         col = col + width + 2,
-        focusable = false,
     })
     for _, window in pairs(windows) do
         vim.api.nvim_win_set_option(window.win_id, 'winhl', string.format('Normal:%s', state.diff.window.hl_group))
@@ -475,22 +474,21 @@ M.show_diff = function(cwd_lines, origin_lines, lnum_changes, filetype)
         vim.api.nvim_win_set_option(window.win_id, 'scrollbind', true)
         vim.api.nvim_win_set_option(window.win_id, 'signcolumn', 'yes')
     end
-    local current_bufs = vim.api.nvim_list_bufs()
-    vim.api.nvim_buf_set_keymap(
-        windows.cwd.buf,
-        'n',
-        '<C-c>',
-        string.format(':lua require("vgit")._close_preview_window(%s, %s)<CR>', windows.cwd.win_id, windows.cwd.origin_id),
-        { silent = true }
-    )
-    for _, current_buf in ipairs(current_bufs) do
-        vim.api.nvim_command(
-            string.format(
-                'autocmd BufEnter <buffer=%s> lua require("vgit")._close_preview_window(%s, %s)',
-                current_buf,
-                windows.cwd.win_id,
-                windows.origin.win_id
-            )
+    local mappings = {'<esc>', '<C-c>'}
+    for _, mapping in ipairs(mappings) do
+        vim.api.nvim_buf_set_keymap(
+            windows.cwd.buf,
+            'n',
+            mapping,
+            string.format(':lua require("vgit")._close_preview_window(%s, %s)<CR>', windows.cwd.win_id, windows.origin.win_id),
+            { silent = true }
+        )
+        vim.api.nvim_buf_set_keymap(
+            windows.origin.buf,
+            'n',
+            mapping,
+            string.format(':lua require("vgit")._close_preview_window(%s, %s)<CR>', windows.cwd.win_id, windows.origin.win_id),
+            { silent = true }
         )
     end
     return windows.cwd.buf, windows.cwd.win_id, windows.origin.buf, windows.origin.win_id

--- a/tests/unit/git_spec.lua
+++ b/tests/unit/git_spec.lua
@@ -676,4 +676,26 @@ describe('git:', function()
 
     end)
 
+    describe('buffer_blames', function()
+        local filename = 'tests/fixtures/simple_file'
+
+        after_each(function()
+            os.execute(string.format('git checkout HEAD -- %s', filename))
+        end)
+
+        it('should return empty array when there are no changes', function()
+            local err, filenames = git.ls();
+            assert.are.same(err, nil)
+            assert.are.same(filenames, {})
+        end)
+
+        it('should return the correct number of filenames when there are changes in the repository', function()
+            add_lines(filename)
+            local err, filenames = git.ls();
+            assert.are.same(err, nil)
+            assert.are.same(filenames, { filename })
+        end)
+
+    end)
+
 end)

--- a/tests/unit/git_spec.lua
+++ b/tests/unit/git_spec.lua
@@ -120,10 +120,17 @@ describe('git:', function()
             invalid_zero = '@@ -0,0 +0,0 @@ foo bar',
         }
 
+        it('should store the headers passed in', function()
+            for _, value in pairs(headers) do
+                local hunk = git.create_hunk(value)
+                assert.are.same(hunk.header, value)
+            end
+        end)
+
         it('should create a hunk from given parameters', function()
             local hunk = git.create_hunk(headers['add'])
             assert.are.same(type(hunk), 'table')
-            local hunk_keys = { 'start', 'finish', 'type', 'diff' }
+            local hunk_keys = { 'header', 'start', 'finish', 'type', 'diff' }
             for key, _ in pairs(hunk) do
                 assert(vim.tbl_contains(hunk_keys, key))
             end
@@ -139,9 +146,11 @@ describe('git:', function()
             local add_hunk = git.create_hunk(headers['add'])
             assert.are.same(add_hunk.start, 18)
             assert.are.same(add_hunk.finish, 18 + 15 - 1)
+
             local remove_hunk = git.create_hunk(headers['remove'])
             assert.are.same(remove_hunk.start, 8)
             assert.are.same(remove_hunk.finish, 8)
+
             local change_hunk = git.create_hunk(headers['change'])
             assert.are.same(change_hunk.start, 10)
             assert.are.same(change_hunk.finish, 10 + 7 - 1)
@@ -154,12 +163,15 @@ describe('git:', function()
                 'world',
                 'this is program speaking',
             }
+
             for _, line in ipairs(lines) do
                 table.insert(hunk.diff, line)
             end
+
             for i, line in ipairs(hunk.diff) do
                 assert.are.same(lines[i], line)
             end
+
             assert.are.same(#hunk.diff, #lines)
         end)
 
@@ -220,6 +232,7 @@ describe('git:', function()
             assert.are.same(data[1].type, 'add')
             assert.are.same(data[2].type, 'change')
             assert.are.same(data[3].type, 'remove')
+
             for i = 1, #lines do
                 -- add
                 if i == 1 then

--- a/tests/unit/git_spec.lua
+++ b/tests/unit/git_spec.lua
@@ -139,11 +139,9 @@ describe('git:', function()
             local add_hunk = git.create_hunk(headers['add'])
             assert.are.same(add_hunk.start, 18)
             assert.are.same(add_hunk.finish, 18 + 15 - 1)
-
             local remove_hunk = git.create_hunk(headers['remove'])
             assert.are.same(remove_hunk.start, 8)
             assert.are.same(remove_hunk.finish, 8)
-
             local change_hunk = git.create_hunk(headers['change'])
             assert.are.same(change_hunk.start, 10)
             assert.are.same(change_hunk.finish, 10 + 7 - 1)
@@ -156,15 +154,12 @@ describe('git:', function()
                 'world',
                 'this is program speaking',
             }
-
             for _, line in ipairs(lines) do
                 table.insert(hunk.diff, line)
             end
-
             for i, line in ipairs(hunk.diff) do
                 assert.are.same(lines[i], line)
             end
-
             assert.are.same(#hunk.diff, #lines)
         end)
 
@@ -225,7 +220,6 @@ describe('git:', function()
             assert.are.same(data[1].type, 'add')
             assert.are.same(data[2].type, 'change')
             assert.are.same(data[3].type, 'remove')
-
             for i = 1, #lines do
                 -- add
                 if i == 1 then

--- a/tests/unit/init_spec.lua
+++ b/tests/unit/init_spec.lua
@@ -25,6 +25,7 @@ describe('init:', function()
                 hunk_reset = true,
                 buffer_preview = true,
                 buffer_reset = true,
+                hunks_quickfix = true,
             }
             for key, _ in pairs(vgit) do
                 assert(known_imports[key])


### PR DESCRIPTION
Changes:
- All project hunks can now be navigatable via a new command called hunks_quickfix
- The user can then use all quickfix commands to navigate between all the hunks in the project
- Previously origin buffer was not focusable, this is no longer the case
- ESC now also closes the diff window