### PR TITLE
Ability to change diff base on the fly

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,10 @@ vim.api.nvim_set_keymap('n', '<leader>gq', ':VGit hunks_quickfix_list<CR>', {
 | buffer_reset | Resets the current buffer to HEAD |
 | hunks_quickfix_list | Opens a populated quickfix window with all the hunks of the project |
 | diff | Opens a populated quickfix window showing all the files that have a change in it |
+| instantiated | Returns true if setup has been called, false otherwise |
+| enabled | Returns true, if plugin is enabled, false otherwise |
+| get_diff_base | Returns the current diff base that all diff and hunks are being compared for all buffers |
+| set_diff_base | Sets the current diff base to a different commit, going forward all future hunks and diffs for a given buffer will be against this commit |
 
 ## Similar Git Plugins
 - [vim-fugitive](https://github.com/tpope/vim-fugitive) :crown:

--- a/lua/vgit/Bstate.lua
+++ b/lua/vgit/Bstate.lua
@@ -4,7 +4,7 @@ local Bstate = {}
 Bstate.__index = Bstate
 
 local function new()
-    return setmetatable({ bufs = {} }, Bstate)
+    return setmetatable({ buf_states = {} }, Bstate)
 end
 
 local function translate_buf(buf)
@@ -13,11 +13,11 @@ local function translate_buf(buf)
 end
 
 function Bstate:contains(buf)
-    return self.bufs[translate_buf(buf)] ~= nil
+    return self.buf_states[translate_buf(buf)] ~= nil
 end
 
 function Bstate:add(buf)
-    self.bufs[translate_buf(buf)] = State.new({
+    self.buf_states[translate_buf(buf)] = State.new({
         filename = '',
         filetype = '',
         project_relative_filename = '',
@@ -30,28 +30,32 @@ function Bstate:add(buf)
 end
 
 function Bstate:remove(buf)
-    local buf_state = self.bufs[translate_buf(buf)]
+    local buf_state = self.buf_states[translate_buf(buf)]
     assert(buf_state ~= nil, 'Buffer is not tracked by VGit')
-    self.bufs[translate_buf(buf)] = nil
+    self.buf_states[translate_buf(buf)] = nil
 end
 
 function Bstate:get(buf, key)
-    local buf_state = self.bufs[translate_buf(buf)]
+    local buf_state = self.buf_states[translate_buf(buf)]
     assert(buf_state ~= nil, 'Buffer is not tracked by VGit')
     return buf_state:get(key)
 end
 
 function Bstate:set(buf, key, value)
-    local buf_state = self.bufs[translate_buf(buf)]
+    local buf_state = self.buf_states[translate_buf(buf)]
     assert(buf_state ~= nil, 'Buffer is not tracked by VGit')
     buf_state:set(key, value)
 end
 
-function Bstate:for_each_buf(fn)
+function Bstate:for_each(fn)
     assert(type(fn) == 'function', 'Invalid function type provided')
-    for key, value in pairs(self.bufs) do
+    for key, value in pairs(self.buf_states) do
         fn(tonumber(key), value)
     end
+end
+
+function Bstate:get_buf_states()
+    return self.buf_states
 end
 
 return {

--- a/lua/vgit/localization.lua
+++ b/lua/vgit/localization.lua
@@ -29,6 +29,7 @@ M.state = State.new({
         toggle_buffer_blames = 'VGit: Failed to retrieve line blame on toggle for the file "%s"',
         buffer_reset = 'VGit: Failed to reset buffer for the file, "%s"',
         setup_tracked_file = 'VGit: Failed to retrieve tracked files for the project',
+        set_diff_base = 'VGit: Failed to set diff base, the commit "%s" is invalid'
     }
 })
 

--- a/tests/unit/Bstate_spec.lua
+++ b/tests/unit/Bstate_spec.lua
@@ -22,7 +22,7 @@ describe('Bstate:', function()
 
         it('should create a Bstate object', function()
             local bstate = Bstate.new()
-            eq(bstate, { bufs = {} })
+            eq(bstate, { buf_states = {} })
         end)
 
     end)
@@ -39,7 +39,7 @@ describe('Bstate:', function()
                 current = atomic_buf_state,
                 initial = atomic_buf_state,
             }
-            eq(bstate.bufs, {
+            eq(bstate.buf_states, {
                 ['1'] = buf_state,
                 ['2'] = buf_state,
                 ['3'] = buf_state,
@@ -54,7 +54,7 @@ describe('Bstate:', function()
             for i = 1, num_cache, 1 do
                 bstate:add(i)
             end
-            eq(#vim.tbl_keys(bstate.bufs), num_cache)
+            eq(#vim.tbl_keys(bstate.buf_states), num_cache)
         end)
 
     end)
@@ -81,6 +81,28 @@ describe('Bstate:', function()
             for i = 101, num_bufs, 1 do
                 eq(bstate:contains(i), false)
             end
+        end)
+
+    end)
+
+    describe('get_bufs', function()
+
+        it('should return all the buf states that exists in the bstate', function()
+            local bstate = Bstate.new()
+            local num_bufs = 100
+            for i = 1, num_bufs, 1 do
+                bstate:add(i)
+            end
+            local buf_states = bstate:get_buf_states()
+            eq(#vim.tbl_keys(buf_states), num_bufs)
+            for _, buf_state in pairs(buf_states) do
+                assert(buf_state, initial_state)
+            end
+        end)
+
+        it('should return empty table if there are no buf states in the bstate', function()
+            local bstate = Bstate.new()
+            assert(bstate:get_buf_states(), {})
         end)
 
     end)

--- a/tests/unit/git_spec.lua
+++ b/tests/unit/git_spec.lua
@@ -8,7 +8,6 @@ local eq = assert.are.same
 local a = require('plenary.async_lib.async')
 local async_void = a.async_void
 local await = a.await
-local scheduler = a.scheduler
 
 local function read_file(filename)
     local file = io.open(filename, "rb")
@@ -745,6 +744,47 @@ describe('git:', function()
                 'tests/unit/highlighter_spec.lua',
                 'tests/unit/init_spec.lua',
             })
+        end))
+
+    end)
+
+    describe('is_commit_valid', function()
+
+        it('should return false if a commit is invalid', async_void(function()
+            local commit_hash = 'someinvalidhash'
+            local is_valid = await(git.is_commit_valid(commit_hash))
+            eq(is_valid, false)
+        end))
+
+        it('should return true if a commit is valid', async_void(function()
+            local commit_hash = '490a4b2928b1fd418a4143f4f0945faf3a15dbf0'
+            local is_valid = await(git.is_commit_valid(commit_hash))
+            eq(is_valid, true)
+        end))
+
+    end)
+
+    describe('get_diff_base', function()
+
+        it('should return "HEAD" when no other diff base has been set', async_void(function()
+            eq(git.get_diff_base(), 'HEAD')
+        end))
+
+
+        it('should return "6a08d97a4bd97574460f33fc1b9e645bfa9d2f703" after diff base is changed', async_void(function()
+            local new_base = '6a08d97a4bd97574460f33fc1b9e645bfa9d2f703'
+            git.set_diff_base(new_base)
+            eq(git.get_diff_base(), new_base)
+        end))
+
+    end)
+
+    describe('set_diff_base', function()
+
+        it('should set the diff base to the new commit hash', async_void(function()
+            local new_base = '6a08d97a4bd97574460f33fc1b9e645bfa9d2f703'
+            git.set_diff_base(new_base)
+            eq(git.get_diff_base(), new_base)
         end))
 
     end)

--- a/tests/unit/init_spec.lua
+++ b/tests/unit/init_spec.lua
@@ -25,6 +25,8 @@ describe('init:', function()
                 toggle_buffer_hunks = true,
                 hunks_quickfix_list = true,
                 toggle_buffer_blames = true,
+                set_diff_base = true,
+                get_diff_base = true,
                 _buf_attach = true,
                 _buf_update = true,
                 _blame_line = true,


### PR DESCRIPTION
Changelog:
- Added `get_diff_base` and `set_diff_base` which can be used to retrieve and set the current diff base on the fly
- Invalid diff base commit hash will result in a error warning and diff wont be set
- Update documentation