### PR TITLE
Views are focusable

### DIFF
--- a/lua/vgit/View.lua
+++ b/lua/vgit/View.lua
@@ -305,6 +305,10 @@ function View:add_keymap(key, action)
     return self
 end
 
+function View:focus()
+    vim.api.nvim_set_current_win(self.state.win_id)
+end
+
 function View:render()
     if self.state.rendered then
         return self

--- a/lua/vgit/ui.lua
+++ b/lua/vgit/ui.lua
@@ -375,6 +375,7 @@ M.show_preview = async_void(function(fetch, filetype)
                 }
             )
         end
+        views.current:focus()
     else
         widget:set_error(true)
         await(scheduler())
@@ -585,6 +586,7 @@ M.show_history = function(fetch, filetype)
         M.state:get('history').indicator.hl,
         { 0, 0 }, { 0, 1 }
     )
+    views.history:focus()
 end
 
 return M


### PR DESCRIPTION
Changelog:
- Views are now focusable with a new method called `focus`
- Buffer history view now has the logs focused by default
- Buffer Preview view now has current window focused by default