### PR TITLE
Diff Strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ require('vgit').setup({
     hunks_enabled = true,
     blames_enabled = true,
     diff_preference = 'horizontal',
+    diff_strategy = 'remote',
     predict_hunk_signs = true,
     hls = {
         VGitBlame = {
@@ -385,7 +386,9 @@ vim.api.nvim_set_keymap('n', '<leader>gq', ':VGit hunks_quickfix_list<CR>', {
 | get_diff_base | Returns the current diff base that all diff and hunks are being compared for all buffers |
 | set_diff_base | Sets the current diff base to a different commit, going forward all future hunks and diffs for a given buffer will be against this commit |
 | get_diff_preference | Returns the current diff preference of the diff, the value will either be "horizontal" or "vertical" |
-| set_diff_preference | Sets the diff preference to your given output , the value can only be "horizontal" or "vertical" |
+| set_diff_preference | Sets the diff preference to your given output, the value can only be "horizontal" or "vertical" |
+| get_diff_strategy | Returns the current diff strategy used to compute hunk signs and buffer preview, the value will either be "remote" or "index" |
+| set_diff_strategy | Sets the diff strategy that will be used to show hunk signs and buffer preview, the value can only be "remote" or "index" |
 | show_debug_logs | Shows all errors that has occured during program execution |
 
 ## Similar Git Plugins

--- a/lua/vgit/fs.lua
+++ b/lua/vgit/fs.lua
@@ -4,14 +4,6 @@ local vim = vim
 
 local M = {}
 
-local function random_string(length)
-    local res = ''
-    for _ = 1, length do
-        res = res .. string.char(math.random(97, 122))
-    end
-    return res
-end
-
 M.relative_path = function(filepath)
     local cwd = vim.loop.cwd()
     if not cwd or not filepath then return filepath end
@@ -56,7 +48,12 @@ M.filename = function(buf)
 end
 
 M.tmpname = function()
-    return string.format('%s_vgit', random_string(6))
+    local length = 6
+    local res = ''
+    for _ = 1, length do
+        res = res .. string.char(math.random(97, 122))
+    end
+    return string.format('/tmp/%s_vgit', res)
 end
 
 M.read_file = function(filepath)

--- a/lua/vgit/git.lua
+++ b/lua/vgit/git.lua
@@ -264,6 +264,7 @@ M.blame_line = wrap(function(filename, lnum, callback)
 end, 3)
 
 M.logs = wrap(function(filename, callback)
+    local timeout = 30000
     local logs = {{
         author_name = M.state:get('config')['user.name'],
         author_email = M.state:get('config')['user.email'],
@@ -276,14 +277,14 @@ M.logs = wrap(function(filename, callback)
         command = 'git',
         args = {
             'log',
+            '--color=never',
             '--pretty=format:"%H-%P-%at-%an-%ae-%s"',
             '--',
             filename,
         },
     })
-    job:start()
     -- BUG: Plenary Job bug, prevents last line to be read.
-    job:wait()
+    job:sync(timeout)
     local result = job:result()
     for _, line in ipairs(result) do
         table.insert(logs, M.create_log(line))
@@ -486,7 +487,7 @@ M.show = wrap(function(filename, commit_hash, callback)
             callback(nil, result)
         end,
     })
-    job:sync()
+    job:start()
 end, 3)
 
 M.reset = wrap(function(filename, callback)

--- a/lua/vgit/git.lua
+++ b/lua/vgit/git.lua
@@ -341,7 +341,52 @@ M.file_hunks = wrap(function(filename_a, filename_b, callback)
     job:start()
 end, 3)
 
-M.hunks = wrap(function(filename, parent_hash, commit_hash, callback)
+M.index_hunks = wrap(function(filename, callback)
+    local result = {}
+    local err = {}
+    local args = {
+        '--no-pager',
+        '-c',
+        'core.safecrlf=false',
+        'diff',
+        '--color=never',
+        string.format('--diff-algorithm=%s', M.constants.diff_algorithm),
+        '--patch-with-raw',
+        '--unified=0',
+        '--',
+        filename,
+    }
+    local job = Job:new({
+        command = 'git',
+        args = args,
+        on_stdout = function(_, data, _)
+            table.insert(result, data)
+        end,
+        on_stderr = function(_, data, _)
+            table.insert(err, data)
+        end,
+        on_exit = function()
+            if #err ~= 0 then
+                return callback(err, nil)
+            end
+            local hunks = {}
+            for _, line in ipairs(result) do
+                if vim.startswith(line, '@@') then
+                    table.insert(hunks, M.create_hunk(line))
+                else
+                    if #hunks > 0 then
+                        local hunk = hunks[#hunks]
+                        table.insert(hunk.diff, line)
+                    end
+                end
+            end
+            return callback(nil, hunks)
+        end,
+    })
+    job:start()
+end, 2)
+
+M.remote_hunks = wrap(function(filename, parent_hash, commit_hash, callback)
     local result = {}
     local err = {}
     local args = {

--- a/lua/vgit/localization.lua
+++ b/lua/vgit/localization.lua
@@ -22,6 +22,7 @@ M.state = State.new({
         invalid_command = 'Invalid command "%s"',
         set_diff_base = 'Failed to set diff base, the commit "%s" is invalid',
         set_diff_preference = 'Failed to set diff preferece, "%s" is invalid',
+        set_diff_strategy = 'Failed to set diff strategy, "%s" is invalid',
     }
 })
 

--- a/tests/unit/git_spec.lua
+++ b/tests/unit/git_spec.lua
@@ -202,7 +202,7 @@ describe('git:', function()
 
     end)
 
-    describe('hunks', function()
+    describe('remote_hunks', function()
         local filename = 'tests/fixtures/simple_file'
 
         after_each(function()
@@ -211,7 +211,7 @@ describe('git:', function()
 
         it('should return only added hunks with correct start and finish', async_void(function()
             local lines = add_lines(filename)
-            local err, data = await(git.hunks(filename))
+            local err, data = await(git.remote_hunks(filename))
             eq(err, nil)
             eq(#data, #lines)
             local counter = 2
@@ -225,7 +225,7 @@ describe('git:', function()
 
         it('should return only removed hunks with correct start and finish', async_void(function()
             local _, _, removed_lines = remove_lines(filename)
-            local err, data = await(git.hunks(filename))
+            local err, data = await(git.remote_hunks(filename))
             eq(err, nil)
             eq(#data, #removed_lines)
             for i, hunk in ipairs(data) do
@@ -237,7 +237,7 @@ describe('git:', function()
 
         it('should return only changed hunks with correct start and finish', async_void(function()
             local _, _, changed_lines = change_lines(filename)
-            local err, data = await(git.hunks(filename))
+            local err, data = await(git.remote_hunks(filename))
             eq(err, nil)
             eq(#data, #changed_lines)
             local counter = 1
@@ -251,7 +251,7 @@ describe('git:', function()
 
         it('should return all possible hunks with correct start and finish', async_void(function()
             local lines = augment_file(filename)
-            local err, data = await(git.hunks(filename))
+            local err, data = await(git.remote_hunks(filename))
             eq(err, nil)
             eq(#data, 3)
             eq(data[1].type, 'add')
@@ -289,7 +289,7 @@ describe('git:', function()
 
         it('should return data table with correct keys', async_void(function()
             local _, lines = add_lines(filename)
-            local err, hunks = await(git.hunks(filename))
+            local err, hunks = await(git.remote_hunks(filename))
             eq(err, nil)
             eq(type(hunks), 'table')
             local diff_err, data = await(git.vertical_diff(lines, hunks))
@@ -310,35 +310,35 @@ describe('git:', function()
 
         it('should have equal number of current_lines and previous_lines for a file with added lines', async_void(function()
             local _, lines= add_lines(filename)
-            local _, hunks = await(git.hunks(filename))
+            local _, hunks = await(git.remote_hunks(filename))
             local _, data = await(git.vertical_diff(lines, hunks))
             eq(#data.current_lines, #data.previous_lines)
         end))
 
         it('should have equal number of current_lines and previous_lines for a file with removed lines', async_void(function()
             local _, lines = remove_lines(filename)
-            local _, hunks = await(git.hunks(filename))
+            local _, hunks = await(git.remote_hunks(filename))
             local _, data = await(git.vertical_diff(lines, hunks))
             eq(#data.current_lines, #data.previous_lines)
         end))
 
         it('should have equal number of current_lines and previous_lines for a file with changed lines', async_void(function()
             local _, lines = change_lines(filename)
-            local _, hunks = await(git.hunks(filename))
+            local _, hunks = await(git.remote_hunks(filename))
             local _, data = await(git.vertical_diff(lines, hunks))
             eq(#data.current_lines, #data.previous_lines)
         end))
 
         it('should have equal number of current_lines and previous_lines for a file with added, removed and changed lines', async_void(function()
             local _,lines = augment_file(filename)
-            local _, hunks = await(git.hunks(filename))
+            local _, hunks = await(git.remote_hunks(filename))
             local _, data = await(git.vertical_diff(lines, hunks))
             eq(#data.current_lines, #data.previous_lines)
         end))
 
         it('should have equal number of current_lines and previous_lines for a file with added lines', async_void(function()
             local _, lines, added_lines = add_lines(filename)
-            local _, hunks = await(git.hunks(filename))
+            local _, hunks = await(git.remote_hunks(filename))
             local _, data = await(git.vertical_diff(lines, hunks))
             local num_added_lines = #added_lines
             assert(#data.current_lines > 0)
@@ -356,7 +356,7 @@ describe('git:', function()
 
         it('should have correct lnum_changes for a file with removed lines', async_void(function()
             local _, lines, removed_lines = remove_lines(filename)
-            local _, hunks = await(git.hunks(filename))
+            local _, hunks = await(git.remote_hunks(filename))
             local _, data = await(git.vertical_diff(lines, hunks))
             local num_removed_lines = #removed_lines
             assert(#data.current_lines > 0)
@@ -375,7 +375,7 @@ describe('git:', function()
 
         it('should have correct lnum_changes for a file with changed lines', async_void(function()
             local _, lines, changed_lines = change_lines(filename)
-            local _, hunks = await(git.hunks(filename))
+            local _, hunks = await(git.remote_hunks(filename))
             local _, data = await(git.vertical_diff(lines, hunks))
             local num_changed_lines = #changed_lines
             assert(#data.current_lines > 0)
@@ -413,7 +413,7 @@ describe('git:', function()
 
         it('should have correct lnum_changes for a file with added, removed and changed lines', async_void(function()
             local _, lines, added_lines, removed_lines, changed_lines = augment_file(filename)
-            local _, hunks = await(git.hunks(filename))
+            local _, hunks = await(git.remote_hunks(filename))
             local _, data = await(git.vertical_diff(lines, hunks))
             local num_added_lines = #added_lines
             local num_removed_lines = #removed_lines
@@ -459,7 +459,7 @@ describe('git:', function()
 
         it('should have correct current_lines and previous_lines for added lines', async_void(function()
             local lines, new_lines, added_lines = add_lines(filename)
-            local _, hunks = await(git.hunks(filename))
+            local _, hunks = await(git.remote_hunks(filename))
             local _, data = await(git.vertical_diff(new_lines, hunks))
             local current_lines = data.current_lines
             local previous_lines = data.previous_lines
@@ -472,7 +472,7 @@ describe('git:', function()
 
         it('should have correct current_lines and previous_lines for removed lines', async_void(function()
             local lines, new_lines, removed_lines = remove_lines(filename)
-            local _, hunks = await(git.hunks(filename))
+            local _, hunks = await(git.remote_hunks(filename))
             local _, data = await(git.vertical_diff(new_lines, hunks))
             local current_lines = data.current_lines
             local previous_lines = data.previous_lines
@@ -486,7 +486,7 @@ describe('git:', function()
 
         it('should have correct current_lines and previous_lines for changed lines', async_void(function()
             local _, new_lines, changed_lines = add_lines(filename)
-            local _, hunks = await(git.hunks(filename))
+            local _, hunks = await(git.remote_hunks(filename))
             local _, data = await(git.vertical_diff(new_lines, hunks))
             local current_lines = data.current_lines
             local previous_lines = data.previous_lines
@@ -498,7 +498,7 @@ describe('git:', function()
 
         it('should have correct current_lines and previous_lines for added, removed and changed lines', async_void(function()
             local _, new_lines, added_lines, removed_lines, changed_lines = augment_file(filename)
-            local _, hunks = await(git.hunks(filename))
+            local _, hunks = await(git.remote_hunks(filename))
             local _, data = await(git.vertical_diff(new_lines, hunks))
             local current_lines = data.current_lines
             for _, index in ipairs(added_lines) do

--- a/tests/unit/init_spec.lua
+++ b/tests/unit/init_spec.lua
@@ -25,6 +25,8 @@ describe('init:', function()
                 buffer_history = true,
                 show_debug_logs = true,
                 apply_highlights = true,
+                get_diff_strategy = true,
+                set_diff_strategy = true,
                 get_diff_preference = true,
                 set_diff_preference = true,
                 toggle_buffer_hunks = true,


### PR DESCRIPTION
Changelog:
- Added Diff Strategy feature.
- Now users can choose how to calculate the diff across their entire project.
- All diff in the repository can now be directly compared to the index of the repository rather than the actual HEAD.
- The user gets two options 'remote' and 'index', by default it's remote. When the user sets it to index all hunks, and buffer preview will now be relative to the repository and the staging that the user does.
- Fixed an issue where timeout error was shown when retrieving logs for extremely large repositories.
- Fixed an error with blame toggle.