### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ vgit.setup({
         action_delay_ms = 300,
     },
     hls = vgit.themes.tokyonight,
-    sign = {
+    signs = {
         VGitViewSignAdd = {
             name = 'DiffAdd',
             line_hl = 'DiffAdd',


### PR DESCRIPTION
According to [the code](https://github.com/tanvirtin/vgit.nvim/blob/e51a2440de3062e86cc0a7c51e973fe23bff6bcc/lua/vgit/sign.lua#L55), it should be `signs`.

Closes #153.