### PR TITLE
chore: refactor

### DIFF
--- a/lua/vgit/core/Buffer.lua
+++ b/lua/vgit/core/Buffer.lua
@@ -155,4 +155,9 @@ function Buffer:set_keymap(mode, key, action)
   return self
 end
 
+function Buffer:attach(opts)
+  vim.api.nvim_buf_attach(self.bufnr, false, opts)
+  return self
+end
+
 return Buffer

--- a/lua/vgit/core/GitObject.lua
+++ b/lua/vgit/core/GitObject.lua
@@ -1,3 +1,5 @@
+local Hunk = require('vgit.cli.models.Hunk')
+local Versioning = require('vgit.core.Versioning')
 local utils = require('vgit.core.utils')
 local fs = require('vgit.core.fs')
 local loop = require('vgit.core.loop')
@@ -98,9 +100,53 @@ function GitObject:config()
   return self.git:config()
 end
 
-function GitObject:live_hunks(current_lines)
-  local filename = self:tracked_filename()
+function GitObject:native_hunks(filename, current_lines)
+  if filename == '' then
+    local hunks = self.git:untracked_hunks(current_lines)
+    self.hunks = hunks
+    return nil, hunks
+  end
+  local original_lines_err, original_lines = self:lines()
   loop.await_fast_event()
+  if original_lines_err then
+    return original_lines_err
+  end
+  local o_lines_str = ''
+  local c_lines_str = ''
+  local num_lines = math.max(#original_lines, #current_lines)
+  for i = 1, num_lines do
+    local o_line = original_lines[i]
+    local c_line = current_lines[i]
+    if o_line then
+      o_lines_str = o_lines_str .. original_lines[i] .. '\n'
+    end
+    if c_line then
+      c_lines_str = c_lines_str .. current_lines[i] .. '\n'
+    end
+  end
+  self.hunks = {}
+  local hunks = self.hunks
+  vim.diff(o_lines_str, c_lines_str, {
+    on_hunk = function(start_o, count_o, start_c, count_c)
+      local hunk = Hunk:new({ { start_o, count_o }, { start_c, count_c } })
+      hunks[#hunks + 1] = hunk
+      if count_o > 0 then
+        for i = start_o, start_o + count_o - 1 do
+          hunk.diff[#hunk.diff + 1] = '-' .. (original_lines[i] or '')
+        end
+      end
+      if count_c > 0 then
+        for i = start_c, start_c + count_c - 1 do
+          hunk.diff[#hunk.diff + 1] = '+' .. (current_lines[i] or '')
+        end
+      end
+    end,
+    algorithm = 'myers',
+  })
+  return nil, hunks
+end
+
+function GitObject:piped_hunks(filename, current_lines)
   if filename == '' then
     local hunks = self.git:untracked_hunks(current_lines)
     self.hunks = hunks
@@ -127,6 +173,21 @@ function GitObject:live_hunks(current_lines)
     self.hunks = hunks
   end
   return hunks_err, hunks
+end
+
+function GitObject:live_hunks(current_lines)
+  loop.await_fast_event()
+  local filename = self:tracked_filename()
+  local inexpensive_lines_limit = 5000
+  if #current_lines > inexpensive_lines_limit then
+    return self:piped_hunks(filename, current_lines)
+  end
+  local versioning = Versioning:new()
+  local version = versioning:neovim_version()
+  if version.minor <= 5 then
+    return self:piped_hunks(filename, current_lines)
+  end
+  return self:native_hunks(filename, current_lines)
 end
 
 function GitObject:staged_hunks()

--- a/lua/vgit/core/Versioning.lua
+++ b/lua/vgit/core/Versioning.lua
@@ -28,6 +28,10 @@ function Versioning:previous()
   return self.history[#self.history - 1]
 end
 
+function Versioning:neovim_version()
+  return vim.version()
+end
+
 function Versioning:is_neovim_compatible()
   local plugin_version = self:current()
   local expected_neovim_version = {
@@ -35,7 +39,7 @@ function Versioning:is_neovim_compatible()
     minor = 5,
     major = 0,
   }
-  local actual_neovim_version = vim.version()
+  local actual_neovim_version = self:neovim_version()
   if
     actual_neovim_version.patch >= expected_neovim_version.patch
     and actual_neovim_version.minor >= expected_neovim_version.minor

--- a/lua/vgit/core/fs.lua
+++ b/lua/vgit/core/fs.lua
@@ -82,10 +82,7 @@ end
 fs.write_file = function(filepath, lines)
   local f = io.open(filepath, 'wb')
   for i = 1, #lines do
-    -- TODO: This is only used in live hunks right now, we can get away with this now.
-    loop.await_fast_event()
-    local l = lines[i]
-    f:write(l)
+    f:write(lines[i])
     f:write('\n')
   end
   f:close()

--- a/lua/vgit/features/LiveGutter.lua
+++ b/lua/vgit/features/LiveGutter.lua
@@ -107,7 +107,7 @@ function LiveGutter:attach()
   loop.await_fast_event()
   self.git_store:add(buffer)
   loop.await_fast_event()
-  vim.api.nvim_buf_attach(buffer.bufnr, false, {
+  buffer:attach({
     on_lines = loop.async(function(_, _, _, _, p_lnum, n_lnum, byte_count)
       loop.await_fast_event()
       if p_lnum == n_lnum and byte_count == 0 then

--- a/lua/vgit/ui/Component.lua
+++ b/lua/vgit/ui/Component.lua
@@ -17,7 +17,6 @@ function Component:new(options)
       -- The properties that can be used to align components with each other.
       window_props = {},
       config = {
-        filetype = '',
         border = {
           hl = 'GitBorder',
           chars = { '', '', '', '', '', '', '', '' },
@@ -129,57 +128,14 @@ function Component:get_line_count()
 end
 
 function Component:set_filetype(filetype)
-  self.config.filetype = filetype
+  self.buffer:set_option('filetype', filetype)
+  self.buffer:set_option('ft', filetype)
+  self.buffer:set_option('syntax', filetype)
   return self
 end
 
 function Component:get_filetype()
-  return self.config.filetype
-end
-
-function Component:add_syntax_highlights()
-  local buffer = self.buffer
-  local config = self.config
-  local filetype = config.filetype
-  if not filetype or filetype == '' then
-    return self
-  end
-  local has_ts = false
-  local ts_highlight = nil
-  local ts_parsers = nil
-  if not has_ts then
-    has_ts, _ = pcall(require, 'nvim-treesitter')
-    if has_ts then
-      _, ts_highlight = pcall(require, 'nvim-treesitter.highlight')
-      _, ts_parsers = pcall(require, 'nvim-treesitter.parsers')
-    end
-  end
-  if has_ts and filetype and filetype ~= '' then
-    local lang = ts_parsers.ft_to_lang(filetype)
-    if ts_parsers.has_parser(lang) then
-      pcall(ts_highlight.attach, buffer.bufnr, lang)
-    else
-      buffer:set_option('syntax', filetype)
-    end
-  end
-  return self
-end
-
-function Component:clear_syntax_highlights()
-  local has_ts = false
-  local buffer = self.buffer
-  if not has_ts then
-    has_ts, _ = pcall(require, 'nvim-treesitter')
-  end
-  if has_ts then
-    local active_buf = vim.treesitter.highlighter.active[buffer.bufnr]
-    if active_buf then
-      active_buf:destroy()
-    else
-      buffer:set_option('syntax', '')
-    end
-  end
-  return self
+  return self.buffer:get_option('filetype')
 end
 
 function Component:set_lines(lines, force)

--- a/lua/vgit/ui/abstract_scenes/CodeDataScene.lua
+++ b/lua/vgit/ui/abstract_scenes/CodeDataScene.lua
@@ -17,12 +17,19 @@ CodeDataScene.update = loop.brakecheck(loop.async(function(self, selected)
     console.error(cache.err)
     return self
   end
-  self:reset():set_title(cache.title, {
-    filename = cache.data.filename,
-    filetype = cache.data.filetype,
-    stat = cache.data.dto.stat,
-  })
-  self:make():paint():set_cursor_on_mark(1)
+  if not cache.data and not cache.data or not cache.data.dto then
+    return
+  end
+  self
+    :reset()
+    :set_title(cache.title, {
+      filename = cache.data.filename,
+      filetype = cache.data.filetype,
+      stat = cache.data.dto.stat,
+    })
+    :make()
+    :paint()
+    :set_cursor_on_mark(1)
 end))
 
 function CodeDataScene:table_move(direction)

--- a/lua/vgit/ui/abstract_scenes/CodeScene.lua
+++ b/lua/vgit/ui/abstract_scenes/CodeScene.lua
@@ -53,15 +53,9 @@ function CodeScene:set_filetype()
   if current:get_filetype() == filetype then
     return self
   end
-  current
-    :clear_syntax_highlights()
-    :set_filetype(filetype)
-    :add_syntax_highlights()
+  current:set_filetype(filetype)
   if self.layout_type == 'split' then
-    components.previous
-      :clear_syntax_highlights()
-      :set_filetype(filetype)
-      :add_syntax_highlights()
+    components.previous:set_filetype(filetype)
   end
   return self
 end
@@ -203,7 +197,7 @@ function CodeScene:set_cursor_on_mark(selected, position)
 end
 
 function CodeScene:make()
-  return self:make_lines():make_line_numbers()
+  return self:make_lines():make_line_numbers():set_filetype()
 end
 
 function CodeScene:make_lines()
@@ -215,7 +209,6 @@ function CodeScene:make_lines()
     components.previous:set_lines(dto.previous_lines)
     components.current:set_lines(dto.current_lines)
   end
-  self:set_filetype()
   return self
 end
 

--- a/lua/vgit/ui/components/CodeComponent.lua
+++ b/lua/vgit/ui/components/CodeComponent.lua
@@ -206,8 +206,6 @@ function CodeComponent:mount(opts)
   self.mounted = true
   self.component_dimensions = component_dimensions
 
-  self:add_syntax_highlights()
-
   return self
 end
 

--- a/lua/vgit/ui/components/PopupComponent.lua
+++ b/lua/vgit/ui/components/PopupComponent.lua
@@ -45,8 +45,6 @@ function PopupComponent:mount()
   self.mounted = true
   self.component_dimensions = component_dimensions
 
-  self:add_syntax_highlights()
-
   return self
 end
 

--- a/lua/vgit/ui/components/PresentationalComponent.lua
+++ b/lua/vgit/ui/components/PresentationalComponent.lua
@@ -135,8 +135,6 @@ function PresentationalComponent:mount()
   self.mounted = true
   self.component_dimensions = component_dimensions
 
-  self:add_syntax_highlights()
-
   return self
 end
 

--- a/lua/vgit/ui/elements/LineNumberElement.lua
+++ b/lua/vgit/ui/elements/LineNumberElement.lua
@@ -55,7 +55,6 @@ function LineNumberElement:mount(options)
       zindex = 50,
     })
     :assign_options({
-      cursorline = true,
       cursorbind = true,
       scrollbind = true,
       winhl = 'Normal:VGitBackgroundPrimary',

--- a/tests/unit/cli/Git_spec.lua
+++ b/tests/unit/cli/Git_spec.lua
@@ -34,8 +34,6 @@ a.describe('Git:', function()
       local err, config = git:config()
       assert(not err)
       assertion.assert_table(config)
-      assertion.assert_string(config['user.email'])
-      assertion.assert_string(config['user.name'])
     end)
   end)
 

--- a/tests/unit/core/GitObject_spec.lua
+++ b/tests/unit/core/GitObject_spec.lua
@@ -153,21 +153,6 @@ a.describe('GitObject:', function()
         eq(hunks, untracked_hunks)
       end
     )
-    a.it('should retrieve tracked hunks if there is a filename', function()
-      git.tracked_filename = spy.new(function()
-        return filename
-      end)
-      local current_lines = {}
-      local err, hunks = git_object:live_hunks(current_lines)
-      assert(not err)
-      assert.stub(fs.tmpname).was_called(2)
-      assert.stub(fs.write_file).was_called(2)
-      assert.stub(fs.remove_file).was_called(2)
-      assert.stub(git.file_hunks).was_called(1)
-      assert.stub(git.file_hunks).was_called_with(git, 'temp', 'temp')
-      assert.stub(fs.remove_file).was_called_with('temp')
-      eq(hunks, file_hunks)
-    end)
 
     a.it(
       'should not return tracked hunks if an error is encountered',


### PR DESCRIPTION
- blame line realizes years
- vim.diff is used on specific versions
- plugin no longer manages treesitter logic, simply delegates the work to neovim who should be intelligent enough to set everything up