### PR TITLE
feat: Project Diff Preview | Goto hunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ require('vgit').setup({
 | buffer_gutter_blame_preview | Opens a preview which shows all the blames related to the lines of the buffer. |
 | buffer_diff_staged_preview | Opens a diff preview showing the diff of the staged changes in the current buffer. |
 | buffer_hunk_staged_preview | Opens a diff preview showing the diff of the staged changes in the current buffer. This preview will open up in a smaller window relative to where your cursor is. |
-| project_diff_preview | Opens a diff preview along with a table of all the files that have been changed, enabling users to see all the files that were changed in the current project. |
+| project_diff_preview | Opens a diff preview along with a table of all the files that have been changed, enabling users to see all the files that were changed in the current project. This preview supports the following commands, "buffer_stage", "buffer_unstage", "buffer_reset", "stage_all" and "unstage_all" |
 | project_hunks_preview | Opens a diff preview along with a table of all the current hunks in the project. Users can use this preview to cycle through all the hunks. |
 | project_hunks_qf | Populate the quickfix list with hunks. Automatically opens the quickfix window. |
 | buffer_hunk_stage | Stages a hunk, if a cursor is on the hunk. |

--- a/lua/vgit/Diff.lua
+++ b/lua/vgit/Diff.lua
@@ -116,6 +116,8 @@ function Diff:unified(lines)
         type = type,
         start = start,
         finish = finish,
+        start_lnum = start - new_lines_added,
+        finish_lnum = finish - new_lines_added,
       }
       for j = start, finish do
         lnum_changes[#lnum_changes + 1] = {
@@ -129,6 +131,8 @@ function Diff:unified(lines)
         type = type,
         start = start + 1,
         finish = nil,
+        start_lnum = start - new_lines_added,
+        finish_lnum = finish - new_lines_added,
       }
       local s = start
       for j = 1, #diff do
@@ -150,6 +154,8 @@ function Diff:unified(lines)
         type = type,
         start = start,
         finish = nil,
+        start_lnum = start - new_lines_added,
+        finish_lnum = finish - new_lines_added,
       }
       local s = start
       for j = 1, #diff do
@@ -252,6 +258,8 @@ function Diff:split(lines)
         type = type,
         start = start,
         finish = finish,
+        start_lnum = start - new_lines_added,
+        finish_lnum = finish - new_lines_added,
       }
       -- Remove the line indicating that these lines were inserted in current_lines.
       for j = start, finish do
@@ -273,6 +281,8 @@ function Diff:split(lines)
         type = type,
         start = start + 1,
         finish = nil,
+        start_lnum = start - new_lines_added,
+        finish_lnum = finish - new_lines_added,
       }
       for j = 1, #diff do
         local line = diff[j]
@@ -299,6 +309,8 @@ function Diff:split(lines)
         type = type,
         start = start,
         finish = nil,
+        start_lnum = start - new_lines_added,
+        finish_lnum = finish - new_lines_added,
       }
       -- Retrieve lines that have been removed and added without "-" and "+".
       local removed_lines, added_lines = hunk:parse_diff()

--- a/lua/vgit/features/scenes/DiffScene.lua
+++ b/lua/vgit/features/scenes/DiffScene.lua
@@ -132,9 +132,9 @@ function DiffScene:show(title, options)
       filetype = data.filetype,
       stat = data.dto.stat,
     })
-    :make()
-    :paint()
-    :set_cursor_on_mark(selected_hunk, 'center')
+    :make_code()
+    :paint_code()
+    :set_code_cursor_on_mark(selected_hunk, 'center')
   console.clear()
   return true
 end

--- a/lua/vgit/features/scenes/GutterBlameScene.lua
+++ b/lua/vgit/features/scenes/GutterBlameScene.lua
@@ -132,9 +132,9 @@ function GutterBlameScene:show(title, options)
       filename = data.filename,
       filetype = data.filetype,
     })
-    :make()
+    :make_code()
+    :paint_code()
     :make_blames()
-    :paint()
   console.clear()
   return true
 end

--- a/lua/vgit/features/scenes/HistoryScene.lua
+++ b/lua/vgit/features/scenes/HistoryScene.lua
@@ -196,10 +196,10 @@ function HistoryScene:show(title, options)
       filetype = data.filetype,
       stat = data.dto.stat,
     })
-    :make()
+    :make_code()
     :make_table()
-    :paint()
-    :set_cursor_on_mark(1)
+    :paint_code()
+    :set_code_cursor_on_mark(1)
   -- Must be after initial fetch
   cache.last_selected = 1
   console.clear()

--- a/lua/vgit/features/scenes/ProjectHunksScene.lua
+++ b/lua/vgit/features/scenes/ProjectHunksScene.lua
@@ -181,9 +181,9 @@ ProjectHunksScene.update = loop.brakecheck(loop.async(function(self, selected)
       filetype = data.filetype,
       stat = data.dto.stat,
     })
-    :make()
-    :paint()
-    :set_cursor_on_mark(data.index, 'top')
+    :make_code()
+    :paint_code()
+    :set_code_cursor_on_mark(data.index, 'top')
     :notify(
       string.format(
         '%s%s/%s Changes',
@@ -270,10 +270,10 @@ function ProjectHunksScene:show(title, options)
       filetype = cache.data.filetype,
       stat = cache.data.dto.stat,
     })
-    :make()
+    :make_code()
     :make_table()
-    :paint()
-    :set_cursor_on_mark(1, 'top')
+    :paint_code()
+    :set_code_cursor_on_mark(1, 'top')
   -- Must be after initial fetch
   cache.last_selected = 1
   console.clear()

--- a/lua/vgit/ui/abstract_scenes/CodeDataScene.lua
+++ b/lua/vgit/ui/abstract_scenes/CodeDataScene.lua
@@ -27,9 +27,9 @@ CodeDataScene.update = loop.brakecheck(loop.async(function(self, selected)
       filetype = cache.data.filetype,
       stat = cache.data.dto.stat,
     })
-    :make()
-    :paint()
-    :set_cursor_on_mark(1)
+    :make_code()
+    :paint_code()
+    :set_code_cursor_on_mark(1)
 end))
 
 function CodeDataScene:table_move(direction)

--- a/lua/vgit/ui/abstract_scenes/CodeScene.lua
+++ b/lua/vgit/ui/abstract_scenes/CodeScene.lua
@@ -160,7 +160,7 @@ function CodeScene:set_cursor(cursor)
   return self
 end
 
-function CodeScene:set_cursor_on_mark(selected, position)
+function CodeScene:set_code_cursor_on_mark(selected, position)
   if not position then
     position = 'top'
   end
@@ -176,12 +176,15 @@ function CodeScene:set_cursor_on_mark(selected, position)
     self:notify('There are no changes')
     return self
   end
-  local component = self.scene.components.current
+  local components = self.scene.components
   if not selected or selected > #marks then
     selected = 1
   end
+  if self.layout_type == 'split' then
+    self.navigation:mark_select(components.previous, selected, marks, position)
+  end
   local mark_index = self.navigation:mark_select(
-    component,
+    components.current,
     selected,
     marks,
     position
@@ -196,7 +199,7 @@ function CodeScene:set_cursor_on_mark(selected, position)
   return self
 end
 
-function CodeScene:make()
+function CodeScene:make_code()
   return self:make_lines():make_line_numbers():set_filetype()
 end
 
@@ -365,7 +368,7 @@ function CodeScene:paint_operation(lnum, metadata, component_type)
   component:transpose_virtual_line_number(number_line, line_number_hl, lnum - 1)
 end
 
-function CodeScene:paint()
+function CodeScene:paint_code()
   local layout_type = self.layout_type or 'unified'
   local current_lines_metadata = self.cache.current_lines_metadata
   local previous_lines_metadata = self.cache.previous_lines_metadata

--- a/lua/vgit/ui/components/TableComponent.lua
+++ b/lua/vgit/ui/components/TableComponent.lua
@@ -110,7 +110,7 @@ function TableComponent:get_dimensions(window_props)
   }
 end
 
-function TableComponent:paint(hls)
+function TableComponent:paint_table(hls)
   for i = 1, #hls do
     local hl_info = hls[i]
     local hl = hl_info.hl
@@ -146,7 +146,7 @@ function TableComponent:set_lines(lines, force)
     max_column_len
   )
   buffer:set_lines(rows)
-  self:paint(hls)
+  self:paint_table(hls)
   self.elements.header:set_lines(column_header)
   self.paddings = paddings
   return self


### PR DESCRIPTION
Closes #171

You can navigate hunks using "hunk_up" and "hunk_down" either you are focused on the table or the code view. 

I suggest binding these navigation command to a useful keymapping.

Pressing `<CR>` either on table or code view will take you directly to the hunk you were navigating when you open the buffer.

Additionally, just being on any hunk and pressing enter should take you to the hunk you are on when you are focused on the code view.