### PR TITLE
fix: symbols default config should not have symbols key

### DIFF
--- a/lua/vgit/settings/symbols.lua
+++ b/lua/vgit/settings/symbols.lua
@@ -1,7 +1,5 @@
 local Config = require('vgit.core.Config')
 
 return Config:new({
-  symbols = {
-    void = '⣿',
-  },
+  void = '⣿',
 })

--- a/lua/vgit/ui/screens/CodeScreen.lua
+++ b/lua/vgit/ui/screens/CodeScreen.lua
@@ -273,7 +273,7 @@ function CodeScreen:make_line_numbers()
         and (lnum_change.type == 'remove' or lnum_change.type == 'void')
       then
         line = string.rep(
-          symbols_setting:get('symbols').void,
+          symbols_setting:get('void'),
           LineNumberElement:get_width()
         )
         lines[#lines + 1] = line
@@ -300,7 +300,7 @@ function CodeScreen:make_line_numbers()
         and (lnum_change.type == 'add' or lnum_change.type == 'void')
       then
         line = string.rep(
-          symbols_setting:get('symbols').void,
+          symbols_setting:get('void'),
           LineNumberElement:get_width()
         )
         lines[#lines + 1] = line
@@ -350,10 +350,7 @@ function CodeScreen:apply_paint_instructions(lnum, metadata, component_type)
     end
     if type == 'void' then
       component:transpose_virtual_text(
-        string.rep(
-          symbols_setting:get('symbols').void,
-          component.window:get_width()
-        ),
+        string.rep(symbols_setting:get('void'), component.window:get_width()),
         line_number_hl,
         lnum - 1,
         0


### PR DESCRIPTION
default `vgit.settings.symbols` config should not have a `"symbols"` key.

With the symbols key, after user-defined configuration is incorrectly applied 

The `Object:data` table goes from:

```
data = {
  symbols = {
    void = '⣿'
  }
}
```

to 

```
data = {
  symbols = {
    void = '⣿'
  },
  void = '^' -- whatever char the user defined
}
```