### PR TITLE
feat: add fallback bare repo (yadm support)

### DIFF
--- a/lua/vgit.lua
+++ b/lua/vgit.lua
@@ -13,6 +13,7 @@ local project_diff_preview_setting = require(
   'vgit.settings.project_diff_preview'
 )
 local signs_setting = require('vgit.settings.signs')
+local git_setting = require('vgit.settings.git')
 local loop = require('vgit.core.loop')
 local symbols_setting = require('vgit.settings.symbols')
 local keymap = require('vgit.core.keymap')
@@ -192,6 +193,7 @@ local settings = {
   hls = hls_setting,
   symbols = symbols_setting,
   signs = signs_setting,
+  git = git_setting,
   live_blame = live_blame_setting,
 }
 
@@ -381,6 +383,7 @@ local function configure_settings(config)
   live_gutter_setting:assign(config_settings.live_gutter)
   scene_setting:assign(config_settings.scene)
   signs_setting:assign(config_settings.signs)
+  git_setting:assign(config_settings.git)
   symbols_setting:assign(config_settings.symbols)
   project_diff_preview_setting:assign(config_settings.project_diff_preview)
 end

--- a/lua/vgit/core/fs.lua
+++ b/lua/vgit/core/fs.lua
@@ -129,4 +129,8 @@ function fs.open(filepath)
   return fs
 end
 
+function fs.make_relative(filepath, cwd)
+  return not cwd and filepath or Path:new(filepath):make_relative(cwd)
+end
+
 return fs

--- a/lua/vgit/core/utils.lua
+++ b/lua/vgit/core/utils.lua
@@ -247,6 +247,14 @@ function utils.list.concat(a, b)
   return a
 end
 
+function utils.list.merge(t, b)
+  local a = vim.deepcopy(t)
+  for _, value in ipairs(b) do
+    a[#a + 1] = value
+  end
+  return a
+end
+
 function utils.list.map(list, callback)
   local new_list = {}
 

--- a/lua/vgit/settings/git.lua
+++ b/lua/vgit/settings/git.lua
@@ -1,0 +1,7 @@
+local Config = require('vgit.core.Config')
+
+return Config({
+  cmd = 'git',
+  fallback_cwd = '',
+  fallback_args = {},
+})


### PR DESCRIPTION
Title: should solve #149.

First, ty for this wonderful plugin, love the meticiousness of your code :-)

That said, before I continue further with this PR (doc, testing, etc) I want to make sure this is how you'd approach it (settings inside `cli/Git.lua` and my `fallback_args` approach).

This PR adds a test for each new `GitObject` coming from a buffer (i.e. has `GitObject`) if the current file is inside a git a dir, if not it will use a new `cwd` as well as supply `--git-dir` and `--work-tree` to the git command so that `vgit` can find the hunks, etc, basically replacing the `git` command with `git --git-dir <path> --work-tree <path>`.

In order to use the new setting you need to add the below to your setup:
```lua
require("vgit").setup {
  settings = {
    git = {
      cmd = 'git', -- optional setting, not really required
      fallback_cwd = vim.fn.expand("$HOME"),
      fallback_args = {
        "--git-dir",
        vim.fn.expand("$HOME/dots/yadm-repo"),
        "--work-tree",
        vim.fn.expand("$HOME"),
      },
    },
  }
}
```

Now if I my current working directory isn't a git repo or the file opened is outside the current working directory `vgit` is still able to show gutter signs as well as stage, reset hunks.

IMO this is better than `gitsigns` support for `yadm` where it basically falls back to running all `git` commands with the `yadm` wrapper script as this can support any git bare repo whether you have yadm installed or not.

This is WIP, wasn't tested fully and I'm pretty sure there are a few issues hiding, just wanted to gauge your interest/input before I continue.