### PR TITLE
feat: added buffer var with current diff stats (#157, #212)

### DIFF
--- a/lua/vgit/core/Buffer.lua
+++ b/lua/vgit/core/Buffer.lua
@@ -326,4 +326,10 @@ function Buffer:set_keymap(mode, key, action)
   return self
 end
 
+function Buffer:set_var(name, value)
+  vim.api.nvim_buf_set_var(self.bufnr, name, value)
+
+  return self
+end
+
 return Buffer

--- a/lua/vgit/features/buffer/LiveGutter.lua
+++ b/lua/vgit/features/buffer/LiveGutter.lua
@@ -44,6 +44,10 @@ LiveGutter.sync = loop.debounce(
     if not hunks then
       buffer:set_cached_live_signs(live_signs)
       return
+    else
+      local diff_status = buffer.git_object:generate_diff_status()
+      loop.await_fast_event() -- vim.schedule
+      buffer:set_var('vgit_status', diff_status)
     end
 
     self:clear(buffer)

--- a/lua/vgit/git/GitObject.lua
+++ b/lua/vgit/git/GitObject.lua
@@ -263,4 +263,22 @@ function GitObject:logs()
   })
 end
 
+function GitObject:generate_diff_status()
+  local hunks = self.hunks or {}
+  local stats_dict = {
+    added = 0,
+    changed = 0,
+    removed = 0,
+  }
+  for _, h in ipairs(hunks) do
+    -- hunk stats only contain added/removed, lines that
+    -- are both added and removed are considered "changed"
+    local changed = math.min(h.stat.added, h.stat.removed)
+    stats_dict.added = stats_dict.added + math.abs(h.stat.added - changed)
+    stats_dict.removed = stats_dict.removed + math.abs(h.stat.removed - changed)
+    stats_dict.changed = stats_dict.changed + changed
+  end
+  return stats_dict
+end
+
 return GitObject


### PR DESCRIPTION
As requested in #218, separate PR to fix #157, #212 rebased for the latest changes.

I did note a bug that didn't exist before https://github.com/tanvirtin/vgit.nvim/commit/e5ba3240258a5097eb149369136e2663dd3d5e71, when opening a non-tracked file `hunk.stat` shows all lines of the current buffer as `added`, this happens on files even outside of the current repo path.

