### PR TITLE
feat: project_stash_preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ require('vgit').setup({
 | buffer_reset | Removes all current changes in the buffer and resets it to the version in HEAD. |
 | project_diff_preview | Opens a diff preview along with a list of all the files that have been changed, enabling users to see all the files that were changed in the current project |
 | project_logs_preview {options} | Opens a preview listing all the logs in the current working branch. Users can filter the list by passing options to this list. Pressing the "tab" key on a list item will keep the item selected. Pressing the "enter" key on the preview will close the preview and open "project_commits_preview" with the selected commits |
+| project_stash_preview | Opens a preview listing all stashes. Pressing the "enter" key on the preview will close the preview and open "project_commits_preview" with the selected stashes |
 | project_commits_preview {commits} | Opens a diff preview along with a list of all your commits |
 | project_hunks_preview | Opens a diff preview along with a foldable list of all the current hunks in the project. Users can use this preview to cycle through all the hunks. |
 | project_hunks_staged_preview | Opens a diff preview along with a foldable list of all the current staged hunks in the project. Users can use this preview to cycle through all the hunks. |

--- a/doc/vgit.txt
+++ b/doc/vgit.txt
@@ -317,6 +317,19 @@ project_diff_preview()                            *vgit.project_diff_preview()*
                 - Stage/unstage a hunk
                 - Open the file
 
+project_logs_preview({commits})                 *vgit.project_logs_preview()*
+                Opens a preview listing all logs in the current working
+                branch. Users can filter the list by passing options to this
+                list. Pressing the "tab" key on a list item will keep the item
+                selected. Pressing the "enter" key on the preview will send the
+                selected commits to "project_commits_preview".
+
+project_stash_preview({commits})                 *vgit.project_stash_preview()*
+                Opens a preview listing all stashes. Pressing the "tab" key on
+                a list item will keep the item selected. Pressing the "enter"
+                key on the preview will send the selected stashes to
+                "project_commits_preview"
+
 project_commits_preview({commits})              *vgit.project_commits_preview()*
                 Opens a preview listing all the logs in the current working
                 branch. Users can filter the list by passing options when

--- a/lua/vgit.lua
+++ b/lua/vgit.lua
@@ -326,6 +326,10 @@ local project = {
     active_screen.activate('project_logs_screen', ...)
   end),
 
+  stash_preview = loop.async(function(...)
+    active_screen.activate('project_stash_screen', ...)
+  end),
+
   commits_preview = loop.async(function(...)
     active_screen.activate('project_commits_screen', ...)
   end),
@@ -507,6 +511,7 @@ return {
   project_reset_all = project.reset_all,
   project_unstage_all = project.unstage_all,
   project_logs_preview = project.logs_preview,
+  project_stash_preview = project.stash_preview,
   project_diff_preview = project.diff_preview,
   project_hunks_preview = project.hunks_preview,
   project_debug_preview = project.debug_preview,

--- a/lua/vgit/Command.lua
+++ b/lua/vgit/Command.lua
@@ -30,6 +30,7 @@ function Command:constructor()
       'project_stage_all',
       'project_unstage_all',
       'project_logs_preview',
+      'project_stash_preview',
       'project_diff_preview',
       'project_hunks_preview',
       'project_debug_preview',

--- a/lua/vgit/features/screens/ProjectCommitsScreen/Query.lua
+++ b/lua/vgit/features/screens/ProjectCommitsScreen/Query.lua
@@ -44,6 +44,7 @@ function Query:fetch(shape, commits)
 
   for i = 1, #commits do
     local commit = commits[i]
+    -- Get the log associated with the commit
     local log_err, log = self.git:log(commit)
     loop.await_fast_event()
 
@@ -51,6 +52,8 @@ function Query:fetch(shape, commits)
       return log_err
     end
 
+    -- We will use the parent_hash and the commit_hash inside
+    -- the log object to list all the files associated with the log.
     local err, files = self.git:ls_log(log)
     loop.await_fast_event()
 
@@ -59,6 +62,10 @@ function Query:fetch(shape, commits)
     end
 
     data[commit] = utils.list.map(files, function(file)
+      -- Log contains the metadata about parent_hash and commit_hash
+      -- File contains the name of the file in that particular working tree.
+      -- Using commit_hash, parent_hash and the name of the file we can easily get the lines
+      -- and hunks to recreate the diffs by feeding this info into our algorithm.
       local datum = {
         id = utils.math.uuid(),
         log = log,

--- a/lua/vgit/features/screens/ProjectStashScreen/Query.lua
+++ b/lua/vgit/features/screens/ProjectStashScreen/Query.lua
@@ -1,0 +1,60 @@
+local Git = require('vgit.git.cli.Git')
+local Object = require('vgit.core.Object')
+
+local Query = Object:extend()
+
+function Query:constructor()
+  return {
+    err = nil,
+    data = nil,
+  }
+end
+
+function Query:reset()
+  self.err = nil
+  self.data = nil
+
+  return self
+end
+
+function Query:fetch()
+  self:reset()
+
+  local err, logs = Git():ls_stash({ is_background = true })
+
+  if err then
+    return err, nil
+  end
+
+  self.err = nil
+
+  self.data = logs
+
+  return self.err, self.data
+end
+
+function Query:get_data()
+  return self.err, self.data
+end
+
+function Query:get_lines()
+  if self.err then
+    return self.err
+  end
+
+  local data = {}
+
+  for i = 1, #self.data do
+    local log = self.data[i]
+
+    data[#data + 1] = string.format('%s %s', log.commit_hash, log.summary)
+  end
+
+  return nil, data
+end
+
+function Query:get_title()
+  return nil, 'Git Stash'
+end
+
+return Query

--- a/lua/vgit/features/screens/ProjectStashScreen/init.lua
+++ b/lua/vgit/features/screens/ProjectStashScreen/init.lua
@@ -1,0 +1,90 @@
+local loop = require('vgit.core.loop')
+local Scene = require('vgit.ui.Scene')
+local Feature = require('vgit.Feature')
+local utils = require('vgit.core.utils')
+local console = require('vgit.core.console')
+local GitLogsView = require('vgit.ui.views.GitLogsView')
+local Query = require('vgit.features.screens.ProjectStashScreen.Query')
+
+local ProjectStashScreen = Feature:extend()
+
+function ProjectStashScreen:constructor()
+  local scene = Scene()
+  local query = Query()
+
+  return {
+    name = 'Stash Screen',
+    scene = scene,
+    query = query,
+    view = GitLogsView(scene, query),
+  }
+end
+
+function ProjectStashScreen:trigger_keypress(key, ...)
+  self.scene:trigger_keypress(key, ...)
+
+  return self
+end
+
+function ProjectStashScreen:show(options)
+  console.log('Processing logs')
+
+  local query = self.query
+
+  loop.await_fast_event()
+  local err = query:fetch(options)
+
+  if err then
+    console.debug.error(err).error(err)
+    return false
+  end
+
+  loop.await_fast_event()
+  self.view:show():set_keymap({
+    {
+      mode = 'n',
+      key = '<tab>',
+      vgit_key = 'keys.tab',
+      handler = loop.async(function()
+        loop.await_fast_event()
+
+        self.view:select()
+      end),
+    },
+    {
+      mode = 'n',
+      key = '<enter>',
+      vgit_key = 'keys.enter',
+      handler = loop.async(function()
+        local view = self.view
+
+        if not view:has_selection() then
+          view:select()
+        end
+
+        vim.cmd('quit')
+
+        loop.await_fast_event()
+        vim.cmd(
+          utils.list.reduce(
+            view:get_selected(),
+            'VGit project_commits_preview',
+            function(cmd, log)
+              return cmd .. ' ' .. log.commit_hash
+            end
+          )
+        )
+      end),
+    },
+  })
+
+  return true
+end
+
+function ProjectStashScreen:destroy()
+  self.scene:destroy()
+
+  return self
+end
+
+return ProjectStashScreen

--- a/lua/vgit/git/cli/Git.lua
+++ b/lua/vgit/git/cli/Git.lua
@@ -1102,4 +1102,40 @@ Git.ls_log = loop.promisify(function(self, log, spec, callback)
   }, spec)):start()
 end, 4)
 
+Git.ls_stash = loop.promisify(function(self, spec, callback)
+  local err = {}
+  local logs = {}
+  local revision_count = 0
+  GitReadStream(utils.object.defaults({
+    command = self.cmd,
+    args = utils.list.merge(self.fallback_args, {
+      '-C',
+      self.cwd,
+      '--no-pager',
+      'stash',
+      'list',
+      '--color=never',
+      '--pretty=format:"%H-%P-%at-%an-%ae-%s"',
+    }),
+    on_stdout = function(line)
+      revision_count = revision_count + 1
+      local log = Log(line, revision_count)
+
+      if log then
+        logs[#logs + 1] = log
+      end
+    end,
+    on_stderr = function(line)
+      err[#err + 1] = line
+    end,
+    on_exit = function()
+      if #err ~= 0 then
+        return callback(err, nil)
+      end
+
+      return callback(nil, logs)
+    end,
+  }, spec)):start()
+end, 3)
+
 return Git

--- a/lua/vgit/ui/active_screen.lua
+++ b/lua/vgit/ui/active_screen.lua
@@ -11,6 +11,7 @@ local GutterBlameScreen = require('vgit.features.screens.GutterBlameScreen')
 local LineBlameScreen = require('vgit.features.screens.LineBlameScreen')
 local DebugScreen = require('vgit.features.screens.DebugScreen')
 local ProjectLogsScreen = require('vgit.features.screens.ProjectLogsScreen')
+local ProjectStashScreen = require('vgit.features.screens.ProjectStashScreen')
 local project_diff_preview_setting = require(
   'vgit.settings.project_diff_preview'
 )
@@ -76,6 +77,12 @@ function active_screen.screens.project_logs_screen(...)
   local project_logs_screen = ProjectLogsScreen()
 
   return project_logs_screen:show({ ... }), project_logs_screen
+end
+
+function active_screen.screens.project_stash_screen(...)
+  local project_stash_screen = ProjectStashScreen()
+
+  return project_stash_screen:show({ ... }), project_stash_screen
 end
 
 function active_screen.screens.project_diff_screen()


### PR DESCRIPTION
Closes: https://github.com/tanvirtin/vgit.nvim/issues/248

- Executing the command `:VGit project_stash_preview` will open a VGit
preview of all stashed entries in your project.
- Users can press <tab> to select the stashes
- Pressing enter will show all changes associated with the selected
  stashes in `project_commits_preview`.
- If nothing is selected, then the entry on the current line will be
  sent to `project_commits_preview`