### PR TITLE
fix(keymapping): revert <C-c> mapping to close screen previews

### DIFF
--- a/lua/vgit/ui/screen_manager.lua
+++ b/lua/vgit/ui/screen_manager.lua
@@ -171,7 +171,6 @@ end
 
 function screen_manager.register_keymaps()
   keymap.set('n', scene_setting:get('keymaps').quit, screen_manager.handle_on_quit_keypress)
-  keymap.set('n', '<C-c>', screen_manager.handle_on_quit_keypress)
 end
 
 return screen_manager


### PR DESCRIPTION
Fixes #297 `<C-c>` mapping is not necessary as  users can define their own mapping to quit screens.