### PR TITLE
fix(git show): allow cwd outside root git dir

### DIFF
--- a/lua/vgit/git/cli/Git.lua
+++ b/lua/vgit/git/cli/Git.lua
@@ -634,9 +634,7 @@ Git.show = loop.suspend(function(self, tracked_filename, commit_hash, spec, call
       '-C',
       self.cwd,
       'show',
-      -- git will attach self.cwd to the command which means we are going to search
-      -- from the current relative path "./" basically just means "${self.cwd}/".
-      string.format('%s:./%s', commit_hash, tracked_filename),
+      string.format('%s:%s', commit_hash, tracked_filename),
     }),
     on_stdout = function(line) result[#result + 1] = line end,
     on_stderr = function(line) err[#err + 1] = line end,
@@ -660,9 +658,7 @@ Git.is_in_remote = loop.suspend(function(self, tracked_filename, commit_hash, sp
       '-C',
       self.cwd,
       'show',
-      -- git will attach self.cwd to the command which means we are going to search
-      -- from the current relative path "./" basically just means "${self.cwd}/".
-      string.format('%s:./%s', commit_hash, tracked_filename),
+      string.format('%s:%s', commit_hash, tracked_filename),
     }),
     on_stderr = function(line)
       if line then


### PR DESCRIPTION
Hi tanvirtin,

When cwd is outside of the root git directory, calls to git show fail due to the `./` prefix added to the filename. I believe this is not required, since we should be using a relative filename from the project git root dir and/or setting `-C` to self.cwd.

To replicate, open any file in a root git directory, `:cd` to some other dir and `:VGit buffer_blame_preview`
```Error executing luv callback:                                                                                                                                                                                                                                  
...ocal/share/nvim/plugged/vgit.nvim/lua/vgit/core/loop.lua:43: coroutine failed :: function: 0x7f583cfe90f8                                                                                                                                                   
stack traceback:                                                                                                                                                                                                                                               
        [C]: in function 'on_exit'                                                                                                                                                                                                                             
        ...hare/nvim/plugged/vgit.nvim/lua/vgit/core/ReadStream.lua:79: in function <...hare/nvim/plugged/vgit.nvim/lua/vgit/core/ReadStream.lua:63>                                                                                                           
stack traceback:                                                                                                                                                                                                                                               
        [C]: in function 'resume_coroutine'                                                                                                                                                                                                                    
        ...ocal/share/nvim/plugged/vgit.nvim/lua/vgit/core/loop.lua:43: in function <...ocal/share/nvim/plugged/vgit.nvim/lua/vgit/core/loop.lua:22>
```

Related to #79 