### PR TITLE
fix(ui): check for nil config in SimpleView

### DIFF
--- a/lua/vgit/ui/views/SimpleView.lua
+++ b/lua/vgit/ui/views/SimpleView.lua
@@ -54,7 +54,7 @@ function SimpleView:set_keymap(configs)
 end
 
 function SimpleView:set_title()
-  if not self.config.elements.header then
+  if self.config.elements and not self.config.elements.header then
     return self
   end
 


### PR DESCRIPTION
Hi tanvirtin,

For screens such as debug view, where `config.elements` is nil, checking for `config.elements.header` results in the below error when trying to set the title of the screen.

First check if config has been provided to SimpleView before checking for a header.

To reproduce, open nvim with tracing on `nvim -c 'VGit toggle_tracing'` and open any debug screen `:VGit project_debug_preview errors`. The below error occurs and the title of the debug screen is not set.

```
Error executing vim.schedule lua callback: coroutine failed :: function: 0x7ff4e83e2870 stack traceback:
        .../nvim/plugged/vgit.nvim/lua/vgit/ui/views/SimpleView.lua: in function 'set_title'
        .../nvim/plugged/vgit.nvim/lua/vgit/ui/views/SimpleView.lua:78: in function 'render'
        .../nvim/plugged/vgit.nvim/lua/vgit/ui/views/SimpleView.lua:91: in function 'show'
        ...vgit.nvim/lua/vgit/features/screens/DebugScreen/init.lua:40: in function 'show'
        ...re/nvim/plugged/vgit.nvim/lua/vgit/ui/screen_manager.lua:87: in function <...re/nvim/plugged/vgit.nvim/lua/vgit/ui/screen_manager.lua:84>
        ...re/nvim/plugged/vgit.nvim/lua/vgit/ui/screen_manager.lua:129: in function 'show'
        .../zdleaf/.local/share/nvim/plugged/vgit.nvim/lua/vgit.lua:78: in function <.../zdleaf/.local/share/nvim/plugged/vgit.nvim/lua/vgit.lua:78>
```

Intention of this check is that we can pass a config table into SimpleView constructor and ensure a header won't be shown on that screen e.g. 
```
view = SimpleView(scene, store, {},  elements = { header = false, footer = false }}})
```