### PR TITLE
fix(git show): cwd is sometimes required

### DIFF
--- a/lua/vgit/git/cli/Git.lua
+++ b/lua/vgit/git/cli/Git.lua
@@ -634,7 +634,7 @@ Git.show = loop.suspend(function(self, tracked_filename, commit_hash, spec, call
       '-C',
       self.cwd,
       'show',
-      string.format('%s:%s', commit_hash, tracked_filename),
+      string.format('%s:%s%s', commit_hash, self.cwd, tracked_filename),
     }),
     on_stdout = function(line) result[#result + 1] = line end,
     on_stderr = function(line) err[#err + 1] = line end,
@@ -658,7 +658,7 @@ Git.is_in_remote = loop.suspend(function(self, tracked_filename, commit_hash, sp
       '-C',
       self.cwd,
       'show',
-      string.format('%s:%s', commit_hash, tracked_filename),
+      string.format('%s:%s%s', commit_hash, self.cwd, tracked_filename),
     }),
     on_stderr = function(line)
       if line then


### PR DESCRIPTION
Hi tanvirtin,

Apologies, noticed today last commit breaks a few things. This is what we wanted.

Commit e0fe17114 ("fix(git show): allow cwd outside root git dir") removed the "./" prefix before the filename when cwd did not equal the root git dir.

Some aspects of VGit like live gutter and hunk preview rely on this, so replace with self.cwd instead.

Thanks