### PR TITLE
Support git log lines containing `-`

### DIFF
--- a/lua/vgit/git/cli/Git.lua
+++ b/lua/vgit/git/cli/Git.lua
@@ -12,6 +12,8 @@ local Status = require('vgit.git.cli.models.Status')
 
 local Git = Object:extend()
 
+local log_line_format = '%H<>%P<>%at<>%an<>%ae<>%s'
+
 function Git:constructor(cwd)
   local newself = {
     cwd = cwd or '',
@@ -243,7 +245,7 @@ Git.log = loop.suspend(function(self, commit_hash, spec, callback)
       'show',
       commit_hash,
       '--color=never',
-      '--pretty=format:"%H-%P-%at-%an-%ae-%s"',
+      '--pretty=format:"' .. log_line_format .. '"',
       '--no-patch',
     }),
     on_stdout = function(line)
@@ -277,7 +279,7 @@ Git.logs = loop.suspend(function(self, options, spec, callback)
       '--no-pager',
       'log',
       '--color=never',
-      '--pretty=format:"%H-%P-%at-%an-%ae-%s"',
+      '--pretty=format:"' .. log_line_format .. '"',
     }, options),
     on_stdout = function(line)
       revision_count = revision_count + 1
@@ -309,7 +311,7 @@ Git.file_logs = loop.suspend(function(self, filename, spec, callback)
       self.cwd,
       'log',
       '--color=never',
-      '--pretty=format:"%H-%P-%at-%an-%ae-%s"',
+      '--pretty=format:"' .. log_line_format .. '"',
       '--',
       filename,
     }),
@@ -1133,7 +1135,7 @@ Git.ls_stash = loop.suspend(function(self, spec, callback)
       'stash',
       'list',
       '--color=never',
-      '--pretty=format:"%H-%P-%at-%an-%ae-%s"',
+      '--pretty=format:"' .. log_line_format .. '"',
     }),
     on_stdout = function(line)
       revision_count = revision_count + 1

--- a/lua/vgit/git/cli/models/Log.lua
+++ b/lua/vgit/git/cli/models/Log.lua
@@ -4,7 +4,7 @@ local utils = require('vgit.core.utils')
 local Log = Object:extend()
 
 function Log:constructor(line, revision_count)
-  local log = vim.split(line, '-')
+  local log = vim.split(line, '<>', { plain = true })
   -- Sometimes you can have multiple parents, in that instance we pick the first!
   local parents = vim.split(log[2], ' ')
 


### PR DESCRIPTION
Quick attempt at fixing #373 by using a more unique string as separator.

Before:
![Screenshot From 2025-01-23 18-22-52](https://github.com/user-attachments/assets/805e4212-f489-4ed5-83f1-682088d05d0f)

After:
![Screenshot From 2025-01-23 18-45-54](https://github.com/user-attachments/assets/91ff8784-1159-4d3e-948c-1da319150063)