### PR TITLE
Safer handling of the git command results

### DIFF
--- a/lua/vgit/git/git_repo.lua
+++ b/lua/vgit/git/git_repo.lua
@@ -12,6 +12,7 @@ function git_repo.discover(filepath)
   local result, err = gitcli.run({ '-C', dirname, 'rev-parse', '--show-toplevel' })
 
   if err then return nil, err end
+  if #result==0 then return nil, {} end
   return result[1]
 end
 
@@ -22,6 +23,7 @@ function git_repo.dirname()
   local result, git_dir_err = gitcli.run({ '-C', reponame, 'rev-parse', '--git-dir' })
   local git_dir = result[1]
   if git_dir_err then return nil, git_dir_err end
+  if #result==0 then return nil, {} end
 
   return reponame .. '/' .. git_dir
 end


### PR DESCRIPTION
I have an issue that is hard to reproduce in astronvim+lazygit.nvim, so I have just debugged it and found the source issue.
There is no handling in the case that for some reason, the git command line returned an empty "stderr"(really, don't know why, maybe command line failures of NVIM for some moments), but the command has exited with a non-zero code. We shall check the return code anyway, however I give here an alternative solution.
Here is a patch that checks that for the directory queries if the result stdout is empty, and if so, it returns a non-nil error `{}`.
If you have a better solution, go ahead. Sorry for not including reproduction, but this suggestion makes the code safer anyway.

Thanks for this great project BTW!

Fixes #403
