### PR TITLE
feat: create extmarks in a named namespace

### DIFF
--- a/lua/vgit/ui/Extmark.lua
+++ b/lua/vgit/ui/Extmark.lua
@@ -11,7 +11,7 @@ function Extmark:constructor(bufnr)
       sign = 100,
       lnum = 1000,
     },
-    ns_id = vim.api.nvim_create_namespace(''),
+    ns_id = vim.api.nvim_create_namespace('vgit.extmarks'),
   }
 end
 


### PR DESCRIPTION
This way, the extmarks can be filtered for the purposes of plugins like statuscol.nvim.