### PR TITLE
fix(#412): remove deprecated method usage -- vim.tbl_islist

### DIFF
--- a/lua/vgit/core/assertion.lua
+++ b/lua/vgit/core/assertion.lua
@@ -63,7 +63,7 @@ function assertion.assert_table(value)
 end
 
 function assertion.assert_list(value)
-  assertion.assert(vim.tbl_islist(value), 'type error :: expected list')
+  assertion.assert(vim.islist(value), 'type error :: expected list')
 
   return assertion
 end

--- a/lua/vgit/core/console.lua
+++ b/lua/vgit/core/console.lua
@@ -86,7 +86,7 @@ function console.debug.get_source_logger(source)
 
     local new_msg = ''
 
-    if vim.tbl_islist(msg) then
+    if vim.islist(msg) then
       for i = 1, #msg do
         local m = msg[i]
         if i == 1 then


### PR DESCRIPTION
Closes #412 