### PR TITLE
fix: Prevent timer leak in loop.debounce

### DIFF
--- a/lua/vgit/core/loop.lua
+++ b/lua/vgit/core/loop.lua
@@ -23,6 +23,7 @@ function loop.debounce(fn, ms)
     local argv = { ... }
     local argc = select('#', ...)
 
+    timer:stop()
     timer:start(ms, 0, function()
       fn(unpack(argv, 1, argc))
     end)


### PR DESCRIPTION
Over the lifetime of a Vim session, vgit.nvim experiences progressive performance degradation. Operations like hunk staging start instant but become increasingly slow (eventually 1-3 seconds per operation) after extended use, requiring a Vim restart to restore performance.

The `loop.debounce` function in `lua/vgit/core/loop.lua` creates a single timer handle but never stops it before calling `timer:start()` again. In libuv, calling `start()` on an already-active timer does not cancel the previous pending callback - it schedules an additional callback. This causes timer callbacks to accumulate over the session.

This affects several high-frequency code paths:
- LiveGutter.fetch_debounced: triggered on every buffer change and git sync
- File system watcher: triggered on every .git directory change
- DiffScreen/ProjectDiffScreen keymaps: triggered on user interactions

With hundreds or thousands of accumulated timer handles, the libuv event loop becomes progressively slower, compounding the problem.

Add `timer:stop()` before `timer:start()` to cancel any pending timer callback before scheduling a new one. This is the standard pattern for reusing timer handles and ensures only one callback is ever pending per debounced function.