### PR TITLE
loop+: Close more timer handles to prevent leak

### DIFF
--- a/lua/vgit/core/loop.lua
+++ b/lua/vgit/core/loop.lua
@@ -16,10 +16,16 @@ function loop.free_textlock(times)
   return loop
 end
 
+-- Registry to track debounced handlers and their cleanup functions
+-- Uses weak keys so handlers can be garbage collected when no longer referenced
+local debounced_registry = setmetatable({}, { __mode = 'k' })
+
 function loop.debounce(fn, ms)
   local timer = vim.loop.new_timer()
+  local closed = false
 
-  return function(...)
+  local debounced = function(...)
+    if closed then return end
     local argv = { ... }
     local argc = select('#', ...)
 
@@ -27,6 +33,37 @@ function loop.debounce(fn, ms)
     timer:start(ms, 0, function()
       fn(unpack(argv, 1, argc))
     end)
+  end
+
+  -- Store cleanup function in registry keyed by the debounced function
+  debounced_registry[debounced] = function()
+    if not closed and timer and not timer:is_closing() then
+      timer:stop()
+      timer:close()
+      closed = true
+      timer = nil
+    end
+  end
+
+  return debounced
+end
+
+-- Close a debounced function's timer handle
+function loop.close_debounced(debounced_fn)
+  local close_fn = debounced_registry[debounced_fn]
+  if close_fn then
+    close_fn()
+    debounced_registry[debounced_fn] = nil
+  end
+end
+
+-- Close all debounced handlers in a table
+function loop.close_debounced_handlers(handlers)
+  if not handlers then return end
+  for _, handler in pairs(handlers) do
+    if type(handler) == 'function' then
+      loop.close_debounced(handler)
+    end
   end
 end
 

--- a/lua/vgit/ui/screen_manager.lua
+++ b/lua/vgit/ui/screen_manager.lua
@@ -94,10 +94,7 @@ function screen_manager.destroy_active_screen()
   local screen = screen_manager.active_screen
   if not screen then return screen_manager end
 
-  local scene = screen.scene
-  if not scene then return screen_manager end
-
-  scene:destroy()
+  screen:destroy()
   screen_manager.active_screen = nil
 
   return screen_manager


### PR DESCRIPTION
Still tracking down various performance issues...

Hunk staging became progressively slower during extended sessions. While 40cf3ff added timer:stop() to prevent callback accumulation, timer handles were never closed with timer:close().

Each diff screen open creates 7 timer handles. When screens close, handles remain in memory via Neovim's keymap registry. After 100 opens: ~700 leaked handles slowing the libuv event loop.

Added registry-based cleanup: debounced_registry tracks cleanup functions, loop.close_debounced_handlers() closes handler tables, screens store references for cleanup in destroy().