### PR TITLE
fix: Suppress VGitSync during staging; 95%+ performance improvement

### DIFF
--- a/lua/vgit/features/buffer/Hunks.lua
+++ b/lua/vgit/features/buffer/Hunks.lua
@@ -68,6 +68,9 @@ function Hunks:stage_all()
   local buffer = git_buffer_store.current()
   if not buffer then return end
 
+  -- Performance: Suppress VGitSync broadcast; refresh only this buffer after delay
+  git_buffer_store.suppress_sync_and_refresh(buffer, 200)
+
   loop.free_textlock()
   local _, err = buffer:stage()
   if err then return console.debug.error(err) end
@@ -81,6 +84,9 @@ function Hunks:cursor_stage()
   local buffer = git_buffer_store.current()
   if not buffer then return end
   if buffer:editing() then return end
+
+  -- Performance: Suppress VGitSync broadcast; refresh only this buffer after delay
+  git_buffer_store.suppress_sync_and_refresh(buffer, 200)
 
   if not buffer:is_tracked() then
     local _, err = buffer:stage()

--- a/lua/vgit/features/screens/DiffScreen/init.lua
+++ b/lua/vgit/features/screens/DiffScreen/init.lua
@@ -138,6 +138,10 @@ function DiffScreen:reset(buffer)
   local filename = self.model:get_filename()
   if not filename then return end
 
+  -- Performance: Suppress VGitSync broadcast; refresh only this buffer after delay
+  local git_buffer_store = require('vgit.git.git_buffer_store')
+  git_buffer_store.suppress_sync_and_refresh(buffer, 200)
+
   loop.free_textlock()
   self.model:reset_file(filename)
 
@@ -185,6 +189,10 @@ function DiffScreen:stage_hunk(buffer)
   local hunk, index = self.diff_view:get_hunk_under_cursor()
   if not hunk then return end
 
+  -- Performance: Suppress VGitSync broadcast; refresh only this buffer after delay
+  local git_buffer_store = require('vgit.git.git_buffer_store')
+  git_buffer_store.suppress_sync_and_refresh(buffer, 200)
+
   self.model:stage_hunk(filename, hunk)
 
   loop.free_textlock()
@@ -211,6 +219,10 @@ function DiffScreen:unstage_hunk(buffer)
   loop.free_textlock()
   local hunk, index = self.diff_view:get_hunk_under_cursor()
   if not hunk then return end
+
+  -- Performance: Suppress VGitSync broadcast; refresh only this buffer after delay
+  local git_buffer_store = require('vgit.git.git_buffer_store')
+  git_buffer_store.suppress_sync_and_refresh(buffer, 200)
 
   loop.free_textlock()
   self.model:unstage_hunk(filename, hunk)
@@ -247,6 +259,10 @@ function DiffScreen:reset_hunk(buffer)
 
   if decision ~= 'yes' and decision ~= 'y' then return end
 
+  -- Performance: Suppress VGitSync broadcast; refresh only this buffer after delay
+  local git_buffer_store = require('vgit.git.git_buffer_store')
+  git_buffer_store.suppress_sync_and_refresh(buffer, 200)
+
   loop.free_textlock()
   self.model:reset_hunk(filename, hunk)
 
@@ -271,6 +287,10 @@ function DiffScreen:stage(buffer)
   local filename = self.model:get_filename()
   if not filename then return end
 
+  -- Performance: Suppress VGitSync broadcast; refresh only this buffer after delay
+  local git_buffer_store = require('vgit.git.git_buffer_store')
+  git_buffer_store.suppress_sync_and_refresh(buffer, 200)
+
   loop.free_textlock()
   self.model:stage_file(filename)
 
@@ -291,6 +311,10 @@ function DiffScreen:unstage(buffer)
   loop.free_textlock()
   local filename = self.model:get_filename()
   if not filename then return end
+
+  -- Performance: Suppress VGitSync broadcast; refresh only this buffer after delay
+  local git_buffer_store = require('vgit.git.git_buffer_store')
+  git_buffer_store.suppress_sync_and_refresh(buffer, 200)
 
   loop.free_textlock()
   self.model:unstage_file(filename)


### PR DESCRIPTION
Builds on top of #422 and #423.

# Description

Fixes performance degradation during staging operations by suppressing redundant VGitSync broadcasts. Achieves 99.6% reduction in buffer refresh calls (1,380 -> 6 LiveGutter:fetch calls) and 95% reduction in total git operations (10,421 -> 564 calls across 41 staging operations).

When staging hunks, every git index change triggered a cascade: filesystem watcher detects change -> VGitSync event fires -> git_buffer_store.for_each() iterates all tracked buffers -> each buffer runs LiveGutter:fetch() -> GitBuffer:diff() -> 3-4 git commands per buffer. With 15 tracked buffers, this meant 15x unnecessary buffer refreshes per stage operation, resulting in thousands of redundant git command calls.

This adds suppress_sync_and_refresh(buffer, ms) API to git_buffer_store that temporarily suppresses VGitSync broadcasts and refreshes only the specified buffer after a delay. Applied to all DiffScreen staging methods (stage_hunk, unstage_hunk, reset_hunk, stage, unstage, reset) and Hunks buffer operations (stage_all, cursor_stage).

Note: External git operations during the suppression window (~200ms) won't trigger a refresh until the next VGitSync event — an acceptable tradeoff given the short window.

Tested with 15 tracked buffers over 41 staging operations. No functional regressions observed - all git operations complete successfully, gutter signs update correctly, and UI remains responsive.

## Performance Summary

**Improvement:**
- Total calls: **95% reduction** (10,421 -> 564)
- LiveGutter:fetch: **99.6% reduction** (1,380 -> 6)
- GitBuffer:diff: **99.6% reduction** (1,381 -> 6)
- git ls-files: **94% reduction** (1,463 -> 87)

## Profiling Details

Environment: 15 tracked buffers, ~40 stage operations (DiffScreen:stage_hunk)

**Before:**
```
Unique operations: 36
Total calls: 10,421

156054ms total (1380x, 113ms avg) - vgit.features.buffer.LiveGutter:fetch
102827ms total (1381x, 74ms avg) - vgit.git.GitBuffer:diff
69420ms total (1838x, 38ms avg) - vgit.git.git_buffer_store.dispatch
41300ms total (1463x, 28ms avg) - gitcli.run: git ls-files
20863ms total (768x, 27ms avg) - gitcli.run: git ls-files -u
18357ms total (468x, 39ms avg) - gitcli.run: git show
11166ms total (39x, 286ms avg) - vgit.features.screens.DiffScreen:stage_hunk
```

**After:**
```
Unique operations: 21
Total calls: 564

6502ms total (41x, 159ms avg) - vgit.features.screens.DiffScreen:stage_hunk
1410ms total (87x, 16ms avg) - gitcli.run: git ls-files
723ms total (38x, 19ms avg) - vgit.git.git_stager.stage_hunk
339ms total (6x, 57ms avg) - vgit.git.git_buffer_store.dispatch
242ms total (6x, 40ms avg) - vgit.features.buffer.LiveGutter:fetch
241ms total (6x, 40ms avg) - vgit.git.GitBuffer:diff
```
