### PR TITLE
perf(DiffScreen): Reduce git commands during hunk staging, 60-75% performance improvement

### DIFF
--- a/lua/vgit/features/screens/DiffScreen/Model.lua
+++ b/lua/vgit/features/screens/DiffScreen/Model.lua
@@ -50,6 +50,19 @@ function Model:get_hunks(lines)
   return self.git_file:live_hunks(lines)
 end
 
+-- Lightweight refresh that skips redundant checks (conflict, status).
+-- Use after staging/unstaging when we know the file state hasn't fundamentally changed.
+function Model:refresh_hunks(filename)
+  local lines, lines_err = self:get_lines(filename)
+  if lines_err then return nil, lines_err end
+
+  local hunks, hunks_err = self:get_hunks(lines)
+  if hunks_err then return nil, hunks_err end
+
+  self.state.diff = Diff():generate(hunks, lines, self:get_layout_type())
+  return self.state.diff
+end
+
 function Model:fetch(filename)
   if not fs.exists(filename) then return nil, { 'Buffer has no diff associated with it' } end
 

--- a/lua/vgit/features/screens/DiffScreen/init.lua
+++ b/lua/vgit/features/screens/DiffScreen/init.lua
@@ -146,7 +146,7 @@ function DiffScreen:reset(buffer)
   self.model:reset_file(filename)
 
   loop.free_textlock()
-  local _, refetch_err = self.model:fetch(buffer:get_name())
+  local _, refetch_err = self.model:refresh_hunks(buffer:get_name())
   loop.free_textlock()
 
   if refetch_err then
@@ -196,7 +196,7 @@ function DiffScreen:stage_hunk(buffer)
   self.model:stage_hunk(filename, hunk)
 
   loop.free_textlock()
-  local _, refetch_err = self.model:fetch(buffer:get_name())
+  local _, refetch_err = self.model:refresh_hunks(buffer:get_name())
   loop.free_textlock()
 
   if refetch_err then
@@ -228,7 +228,7 @@ function DiffScreen:unstage_hunk(buffer)
   self.model:unstage_hunk(filename, hunk)
 
   loop.free_textlock()
-  local _, refetch_err = self.model:fetch(buffer:get_name())
+  local _, refetch_err = self.model:refresh_hunks(buffer:get_name())
   loop.free_textlock()
 
   if refetch_err then
@@ -267,7 +267,7 @@ function DiffScreen:reset_hunk(buffer)
   self.model:reset_hunk(filename, hunk)
 
   loop.free_textlock()
-  local _, refetch_err = self.model:fetch(buffer:get_name())
+  local _, refetch_err = self.model:refresh_hunks(buffer:get_name())
   loop.free_textlock()
 
   if refetch_err then
@@ -295,7 +295,7 @@ function DiffScreen:stage(buffer)
   self.model:stage_file(filename)
 
   loop.free_textlock()
-  local _, refetch_err = self.model:fetch(buffer:get_name())
+  local _, refetch_err = self.model:refresh_hunks(buffer:get_name())
   loop.free_textlock()
 
   if refetch_err then
@@ -320,7 +320,7 @@ function DiffScreen:unstage(buffer)
   self.model:unstage_file(filename)
 
   loop.free_textlock()
-  local _, refetch_err = self.model:fetch(buffer:get_name())
+  local _, refetch_err = self.model:refresh_hunks(buffer:get_name())
   loop.free_textlock()
 
   if refetch_err then


### PR DESCRIPTION
Builds on top of #425; if you rebase merge #425 there will be no conflicts for rebase merging this one.

## Description

After staging/unstaging a hunk, DiffScreen calls Model:fetch() to refresh the view. This runs several git commands that are unnecessary when we know the file state hasn't fundamentally changed:

- git rev-parse --show-toplevel (GitFile creation)
- git status (conflict check)
- git status (file status)

Add Model:refresh_hunks() which skips these redundant checks and only fetches what's needed: current lines and updated hunks. This reduces git commands from ~4-6 to ~1-2 per staging operation (60-75% or roughly 3-4x improvement)