### PR TITLE
fix: Staging fails when cwd differs from repo root

### DIFF
--- a/lua/vgit/features/screens/DiffScreen/Model.lua
+++ b/lua/vgit/features/screens/DiffScreen/Model.lua
@@ -112,37 +112,33 @@ function Model:get_filetype()
   return self.git_file:get_filetype()
 end
 
-function Model:stage_hunk(filename, hunk)
-  local git_file = GitFile(filename)
-  if not git_file:is_tracked() then return git_file:stage() end
+function Model:stage_hunk(hunk)
+  if not self.git_file:is_tracked() then return self.git_file:stage() end
 
-  return git_file:stage_hunk(hunk)
+  return self.git_file:stage_hunk(hunk)
 end
 
-function Model:unstage_hunk(filename, hunk)
-  local git_file = GitFile(filename)
-  if not git_file:is_tracked() then return git_file:unstage() end
+function Model:unstage_hunk(hunk)
+  if not self.git_file:is_tracked() then return self.git_file:unstage() end
 
-  return git_file:unstage_hunk(hunk)
+  return self.git_file:unstage_hunk(hunk)
 end
 
-function Model:reset_hunk(filename, hunk)
-  local git_file = GitFile(filename)
-  return git_file:reset_hunk(hunk)
+function Model:reset_hunk(hunk)
+  return self.git_file:reset_hunk(hunk)
 end
 
-function Model:stage_file(filename)
-  local reponame = git_repo.discover()
-  return git_stager.stage(reponame, filename)
+function Model:stage_file()
+  return self.git_file:stage()
 end
 
-function Model:unstage_file(filename)
-  local reponame = git_repo.discover()
-  return git_stager.unstage(reponame, filename)
+function Model:unstage_file()
+  return self.git_file:unstage()
 end
 
-function Model:reset_file(filename)
-  local reponame = git_repo.discover()
+function Model:reset_file()
+  local reponame = self.git_file.reponame
+  local filename = self.git_file.filename
   if git_repo.has(reponame, filename) then return git_repo.reset(reponame, filename) end
 
   return git_repo.clean(reponame, filename)

--- a/lua/vgit/features/screens/DiffScreen/init.lua
+++ b/lua/vgit/features/screens/DiffScreen/init.lua
@@ -143,7 +143,7 @@ function DiffScreen:reset(buffer)
   git_buffer_store.suppress_sync_and_refresh(buffer, 200)
 
   loop.free_textlock()
-  self.model:reset_file(filename)
+  self.model:reset_file()
 
   loop.free_textlock()
   local _, refetch_err = self.model:refresh_hunks(buffer:get_name())
@@ -193,7 +193,7 @@ function DiffScreen:stage_hunk(buffer)
   local git_buffer_store = require('vgit.git.git_buffer_store')
   git_buffer_store.suppress_sync_and_refresh(buffer, 200)
 
-  self.model:stage_hunk(filename, hunk)
+  self.model:stage_hunk(hunk)
 
   loop.free_textlock()
   local _, refetch_err = self.model:refresh_hunks(buffer:get_name())
@@ -225,7 +225,7 @@ function DiffScreen:unstage_hunk(buffer)
   git_buffer_store.suppress_sync_and_refresh(buffer, 200)
 
   loop.free_textlock()
-  self.model:unstage_hunk(filename, hunk)
+  self.model:unstage_hunk(hunk)
 
   loop.free_textlock()
   local _, refetch_err = self.model:refresh_hunks(buffer:get_name())
@@ -264,7 +264,7 @@ function DiffScreen:reset_hunk(buffer)
   git_buffer_store.suppress_sync_and_refresh(buffer, 200)
 
   loop.free_textlock()
-  self.model:reset_hunk(filename, hunk)
+  self.model:reset_hunk(hunk)
 
   loop.free_textlock()
   local _, refetch_err = self.model:refresh_hunks(buffer:get_name())
@@ -292,7 +292,7 @@ function DiffScreen:stage(buffer)
   git_buffer_store.suppress_sync_and_refresh(buffer, 200)
 
   loop.free_textlock()
-  self.model:stage_file(filename)
+  self.model:stage_file()
 
   loop.free_textlock()
   local _, refetch_err = self.model:refresh_hunks(buffer:get_name())
@@ -317,7 +317,7 @@ function DiffScreen:unstage(buffer)
   git_buffer_store.suppress_sync_and_refresh(buffer, 200)
 
   loop.free_textlock()
-  self.model:unstage_file(filename)
+  self.model:unstage_file()
 
   loop.free_textlock()
   local _, refetch_err = self.model:refresh_hunks(buffer:get_name())

--- a/lua/vgit/features/screens/ProjectDiffScreen/Model.lua
+++ b/lua/vgit/features/screens/ProjectDiffScreen/Model.lua
@@ -219,7 +219,9 @@ function Model:get_diff()
 end
 
 function Model:stage_hunk(filename, hunk)
-  local git_file = GitFile(filename)
+  -- Use absolute path to avoid issues when cwd differs from repo root
+  local filepath = self.state.reponame .. '/' .. filename
+  local git_file = GitFile(filepath)
   if not git_file:is_tracked() then return git_file:stage() end
 
   local file, err = git_file:status()
@@ -230,45 +232,43 @@ function Model:stage_hunk(filename, hunk)
 end
 
 function Model:unstage_hunk(filename, hunk)
-  local git_file = GitFile(filename)
+  -- Use absolute path to avoid issues when cwd differs from repo root
+  local filepath = self.state.reponame .. '/' .. filename
+  local git_file = GitFile(filepath)
   if not git_file:is_tracked() then return git_file:unstage() end
 
   local file, err = git_file:status()
   if err then return nil, err end
 
-  if file:has('D ') or file:has(' D') then return git_file:unstage(filename) end
+  if file:has('D ') or file:has(' D') then return git_file:unstage() end
   return git_file:unstage_hunk(hunk)
 end
 
 function Model:stage_file(filename)
-  local reponame = git_repo.discover()
-  return git_stager.stage(reponame, filename)
+  return git_stager.stage(self.state.reponame, filename)
 end
 
 function Model:unstage_file(filename)
-  local reponame = git_repo.discover()
-  return git_stager.unstage(reponame, filename)
+  return git_stager.unstage(self.state.reponame, filename)
 end
 
 function Model:reset_file(filename)
-  local reponame = git_repo.discover()
+  local reponame = self.state.reponame
   if git_repo.has(reponame, filename) then return git_repo.reset(reponame, filename) end
 
   return git_repo.clean(reponame, filename)
 end
 
 function Model:stage_all()
-  local reponame = git_repo.discover()
-  return git_stager.stage(reponame)
+  return git_stager.stage(self.state.reponame)
 end
 
 function Model:unstage_all()
-  local reponame = git_repo.discover()
-  return git_stager.unstage(reponame)
+  return git_stager.unstage(self.state.reponame)
 end
 
 function Model:reset_all()
-  local reponame = git_repo.discover()
+  local reponame = self.state.reponame
   local _, reset_err = git_repo.reset(reponame)
   if reset_err then return nil, reset_err end
 


### PR DESCRIPTION
When `GitFile(filename)` was created with a relative path, `git_repo.discover()` resolved it relative to the current working directory. If the user `:cd`'d to a subdirectory, paths got resolved incorrectly and staging operations silently failed.

- DiffScreen: Use `self.git_file` instead of creating new GitFile
- ProjectDiffScreen: Construct absolute paths using stored reponame
- Remove redundant `filename` params from Model methods
- Remove redundant `git_repo.discover()` calls (use stored reponame)
- Fix extra unused arg in `git_file:unstage(filename)`