### PR TITLE
ProjectDiffScreen: Better navigation, hunk reset, UX improvements, and file list display bugfixes

### DIFF
--- a/lua/vgit/core/Diff.lua
+++ b/lua/vgit/core/Diff.lua
@@ -238,6 +238,11 @@ function Diff:generate_split_conflict(conflicts, lines)
 end
 
 function Diff:generate_unified_deleted(hunks, lines)
+  if #hunks == 0 then return utils.object.extend(self, {
+    lines = lines,
+    hunks = hunks,
+  }) end
+
   local hunk = hunks[1]
   local type = hunk.type
   local diff = hunk.diff
@@ -271,6 +276,12 @@ function Diff:generate_unified_deleted(hunks, lines)
 end
 
 function Diff:generate_split_deleted(hunks, lines)
+  if #hunks == 0 then return utils.object.extend(self, {
+    current_lines = {},
+    previous_lines = lines,
+    hunks = hunks,
+  }) end
+
   local hunk = hunks[1]
   local type = hunk.type
   local diff = hunk.diff

--- a/lua/vgit/core/keymap.lua
+++ b/lua/vgit/core/keymap.lua
@@ -67,6 +67,7 @@ function keymap.buffer_set(buffer, opts, callback)
     desc = desc,
     silent = silent,
     noremap = noremap,
+    nowait = true,
     buffer = buffer.bufnr,
   })
 

--- a/lua/vgit/features/screens/ProjectDiffScreen/Model.lua
+++ b/lua/vgit/features/screens/ProjectDiffScreen/Model.lua
@@ -244,6 +244,12 @@ function Model:unstage_hunk(filename, hunk)
   return git_file:unstage_hunk(hunk)
 end
 
+function Model:reset_hunk(filename, hunk)
+  local filepath = self.state.reponame .. '/' .. filename
+  local git_file = GitFile(filepath)
+  return git_file:reset_hunk(hunk)
+end
+
 function Model:stage_file(filename)
   return git_stager.stage(self.state.reponame, filename)
 end

--- a/lua/vgit/features/screens/ProjectDiffScreen/init.lua
+++ b/lua/vgit/features/screens/ProjectDiffScreen/init.lua
@@ -156,12 +156,27 @@ function ProjectDiffScreen:unstage_hunk()
   self:render(function()
     local has_staged = false
     self.status_list_view:each_status(function(status, entry_type)
-      if entry_type == 'staged' and status.filename == entry.status.filename then has_staged = true end
+      if entry_type == 'staged' and status.filename == filename then
+        has_staged = true
+      end
     end)
-    self:move_to(function(status, entry_type)
-      if has_staged and entry_type == 'unstaged' then return false end
-      return status.filename == entry.status.filename
-    end)
+
+    if has_staged then
+      -- Stay on the staged entry for this file
+      self:move_to(function(status, entry_type)
+        return status.filename == filename and entry_type == 'staged'
+      end)
+    else
+      -- File fully unstaged - jump to next staged file, else this file's unstaged
+      local found = self:move_to(function(_, entry_type)
+        return entry_type == 'staged'
+      end)
+      if not found then
+        self:move_to(function(status)
+          return status.filename == filename
+        end)
+      end
+    end
   end)
 end
 

--- a/lua/vgit/features/screens/ProjectDiffScreen/init.lua
+++ b/lua/vgit/features/screens/ProjectDiffScreen/init.lua
@@ -113,12 +113,27 @@ function ProjectDiffScreen:stage_hunk()
   self:render(function()
     local has_unstaged = false
     self.status_list_view:each_status(function(status, entry_type)
-      if entry_type == 'unstaged' and status.filename == entry.status.filename then has_unstaged = true end
+      if entry_type == 'unstaged' and status.filename == filename then
+        has_unstaged = true
+      end
     end)
-    self:move_to(function(status, entry_type)
-      if has_unstaged and entry_type == 'staged' then return false end
-      return status.filename == entry.status.filename
-    end)
+
+    if has_unstaged then
+      -- Stay on the unstaged entry for this file
+      self:move_to(function(status, entry_type)
+        return status.filename == filename and entry_type == 'unstaged'
+      end)
+    else
+      -- File fully staged - jump to next unstaged file, else this file's staged
+      local found = self:move_to(function(_, entry_type)
+        return entry_type == 'unstaged'
+      end)
+      if not found then
+        self:move_to(function(status)
+          return status.filename == filename
+        end)
+      end
+    end
   end)
 end
 

--- a/lua/vgit/features/screens/ProjectDiffScreen/init.lua
+++ b/lua/vgit/features/screens/ProjectDiffScreen/init.lua
@@ -817,6 +817,31 @@ function ProjectDiffScreen:create()
   return true
 end
 
+-- Called when quit key is pressed. Returns true if quit was handled.
+function ProjectDiffScreen:on_quit()
+  local diff_component = self.scene:get('current')
+  if not diff_component:is_focused() then
+    return false
+  end
+
+  local filepath = self.model:get_filepath()
+  if not filepath then
+    return false
+  end
+
+  local file_lnum = self.diff_view:get_file_lnum()
+  loop.free_textlock()
+
+  self:destroy()
+  fs.open(filepath)
+
+  if file_lnum then
+    Window(0):set_lnum(file_lnum):position_cursor('center')
+  end
+
+  return true
+end
+
 function ProjectDiffScreen:destroy()
   -- Clean up timer handles from debounced keymap handlers
   loop.close_debounced_handlers(self.diff_keymaps)

--- a/lua/vgit/features/screens/ProjectDiffScreen/init.lua
+++ b/lua/vgit/features/screens/ProjectDiffScreen/init.lua
@@ -1,6 +1,7 @@
 local fs = require('vgit.core.fs')
 local Scene = require('vgit.ui.Scene')
 local loop = require('vgit.core.loop')
+local event = require('vgit.core.event')
 local utils = require('vgit.core.utils')
 local Buffer = require('vgit.core.Buffer')
 local Object = require('vgit.core.Object')
@@ -443,6 +444,8 @@ function ProjectDiffScreen:enter_view()
 
   fs.open(filepath)
   Window(0):set_lnum(mark.top_relative):position_cursor('center')
+
+  event.emit('VGitSync')
 end
 
 function ProjectDiffScreen:open_file()
@@ -463,6 +466,8 @@ function ProjectDiffScreen:open_file()
   end
 
   Window(0):set_lnum(mark.top_relative):position_cursor('center')
+
+  event.emit('VGitSync')
 end
 
 function ProjectDiffScreen:render(on_status_list_render)
@@ -932,6 +937,8 @@ function ProjectDiffScreen:on_quit()
   if file_lnum then
     Window(0):set_lnum(file_lnum):position_cursor('center')
   end
+
+  event.emit('VGitSync')
 
   return true
 end

--- a/lua/vgit/features/screens/ProjectDiffScreen/init.lua
+++ b/lua/vgit/features/screens/ProjectDiffScreen/init.lua
@@ -81,11 +81,13 @@ function ProjectDiffScreen:constructor(opts)
 end
 
 function ProjectDiffScreen:hunk_up()
-  self.diff_view:prev()
+  local hunk_alignment = project_diff_preview_setting:get('hunk_alignment')
+  self.diff_view:prev(hunk_alignment)
 end
 
 function ProjectDiffScreen:hunk_down()
-  self.diff_view:next()
+  local hunk_alignment = project_diff_preview_setting:get('hunk_alignment')
+  self.diff_view:next(hunk_alignment)
 end
 
 function ProjectDiffScreen:move_to(query_fn)
@@ -327,17 +329,19 @@ function ProjectDiffScreen:render(on_status_list_render)
   local list_item = self.status_list_view:get_current_list_item()
   self.model:set_entry_id(list_item.id)
 
+  local hunk_alignment = project_diff_preview_setting:get('hunk_alignment')
   self.diff_view:render()
-  self.diff_view:move_to_hunk()
+  self.diff_view:move_to_hunk(nil, hunk_alignment)
 end
 
 function ProjectDiffScreen:handle_list_move()
   local list_item = self.status_list_view:move()
   if not list_item then return end
 
+  local hunk_alignment = project_diff_preview_setting:get('hunk_alignment')
   self.model:set_entry_id(list_item.id)
   self.diff_view:render()
-  self.diff_view:move_to_hunk()
+  self.diff_view:move_to_hunk(nil, hunk_alignment)
 end
 
 function ProjectDiffScreen:focus_relative_buffer_entry(buffer)
@@ -364,8 +368,9 @@ function ProjectDiffScreen:toggle_focus()
   local diff_component = self.scene:get('current')
 
   if list_component:is_focused() then
+    local hunk_alignment = project_diff_preview_setting:get('hunk_alignment')
     diff_component:focus()
-    self.diff_view:move_to_hunk(1, 'center')
+    self.diff_view:move_to_hunk(1, hunk_alignment)
   else
     list_component:focus()
   end

--- a/lua/vgit/features/screens/ProjectDiffScreen/init.lua
+++ b/lua/vgit/features/screens/ProjectDiffScreen/init.lua
@@ -359,6 +359,18 @@ function ProjectDiffScreen:focus_relative_buffer_entry(buffer)
   end)
 end
 
+function ProjectDiffScreen:toggle_focus()
+  local list_component = self.scene:get('list')
+  local diff_component = self.scene:get('current')
+
+  if list_component:is_focused() then
+    diff_component:focus()
+    self.diff_view:move_to_hunk(1, 'center')
+  else
+    list_component:focus()
+  end
+end
+
 function ProjectDiffScreen:setup_list_keymaps()
   local keymaps = project_diff_preview_setting:get('keymaps')
 
@@ -411,6 +423,13 @@ function ProjectDiffScreen:setup_list_keymaps()
       handler = loop.coroutine(function()
         self:reset_all()
       end),
+    },
+    {
+      mode = 'n',
+      mapping = keymaps.toggle_focus,
+      handler = function()
+        self:toggle_focus()
+      end,
     },
   })
 end
@@ -499,6 +518,13 @@ function ProjectDiffScreen:setup_diff_keymaps()
       mode = 'n',
       mapping = keymaps.commit,
       handler = handlers.commit,
+    },
+    {
+      mode = 'n',
+      mapping = keymaps.toggle_focus,
+      handler = function()
+        self:toggle_focus()
+      end,
     },
     {
       mode = 'n',

--- a/lua/vgit/settings/project_diff_preview.lua
+++ b/lua/vgit/settings/project_diff_preview.lua
@@ -48,5 +48,13 @@ return Config({
       key = '<Tab>',
       desc = 'Switch focus between file list and diff preview'
     },
+    next = {
+      key = 'J',
+      desc = 'Next'
+    },
+    previous = {
+      key = 'K',
+      desc = 'Previous'
+    },
   },
 })

--- a/lua/vgit/settings/project_diff_preview.lua
+++ b/lua/vgit/settings/project_diff_preview.lua
@@ -38,5 +38,9 @@ return Config({
       key = 'R',
       desc = 'Reset all'
     },
+    toggle_focus = {
+      key = '<Tab>',
+      desc = 'Switch focus between file list and diff preview'
+    },
   },
 })

--- a/lua/vgit/settings/project_diff_preview.lua
+++ b/lua/vgit/settings/project_diff_preview.lua
@@ -1,6 +1,8 @@
 local Config = require('vgit.core.Config')
 
 return Config({
+  -- Alignment when jumping to a hunk: 'top', 'center', or 'bottom'
+  hunk_alignment = 'center',
   keymaps = {
     commit = {
       key = 'C',

--- a/lua/vgit/settings/project_diff_preview.lua
+++ b/lua/vgit/settings/project_diff_preview.lua
@@ -28,6 +28,10 @@ return Config({
       key = 'gu',
       desc = 'Unstage hunk'
     },
+    buffer_hunk_reset = {
+      key = 'gr',
+      desc = 'Reset hunk'
+    },
     stage_all = {
       key = 'S',
       desc = 'Stage all'

--- a/lua/vgit/ui/ComponentPlot.lua
+++ b/lua/vgit/ui/ComponentPlot.lua
@@ -89,9 +89,9 @@ function ComponentPlot:configure_row()
   local has_footer = config.footer
   local footer_win_plot = self.footer_win_plot
 
-  -- Row
+  -- Row: Position header at current row, push content down by header height
   if has_header then
-    self.header_win_plot.row = win_plot.row + header_element_height
+    self.header_win_plot.row = win_plot.row
     win_plot.row = win_plot.row + header_element_height
   end
 

--- a/lua/vgit/ui/elements/HeaderElement.lua
+++ b/lua/vgit/ui/elements/HeaderElement.lua
@@ -43,7 +43,7 @@ function HeaderElement:mount(opts)
     style = 'minimal',
     focusable = false,
     relative = 'editor',
-    row = opts.row - HeaderElement:get_height(),
+    row = opts.row,
     col = opts.col,
     width = opts.width,
     height = 1,

--- a/lua/vgit/ui/screen_manager.lua
+++ b/lua/vgit/ui/screen_manager.lua
@@ -120,9 +120,10 @@ function screen_manager.create(screen_name, ...)
       {
         mode = 'n',
         key = scene_setting:get('keymaps').quit,
-        handler = function()
+        handler = loop.coroutine(function()
+          if screen.on_quit and screen:on_quit() then return end
           screen_manager.destroy_active_screen()
-        end
+        end)
       }
     })
   end

--- a/lua/vgit/ui/views/DiffView.lua
+++ b/lua/vgit/ui/views/DiffView.lua
@@ -500,6 +500,28 @@ function DiffView:get_hunk_under_cursor()
   if selected then return hunks[selected], selected end
 end
 
+-- Returns the actual file line number for the current cursor position.
+-- For removed lines (which don't exist in the file), returns the closest
+-- valid line number above.
+function DiffView:get_file_lnum()
+  local lines_changes = self.state.current_lines_changes
+  if not lines_changes or #lines_changes == 0 then return nil end
+
+  local lnum = self.scene:get('current'):get_lnum()
+  if lnum > #lines_changes then lnum = #lines_changes end
+
+  -- Search current line and above for a valid line number
+  for i = lnum, 1, -1 do
+    local entry = lines_changes[i]
+    if entry and entry.line_number then
+      local file_lnum = tonumber(entry.line_number:match('%d+'))
+      if file_lnum then return file_lnum end
+    end
+  end
+
+  return nil
+end
+
 function DiffView:set_lnum(lnum, position)
   if self.props.layout_type() == 'split' then self.scene:get('previous'):set_lnum(lnum):position_cursor(position) end
   self.scene:get('current'):set_lnum(lnum):position_cursor(position)


### PR DESCRIPTION
# `ProjectDiffScreen` UX Improvements, Features, and Fixes

## Demo

[Video link](https://drive.google.com/file/d/10N3P_Vww8-8Wtrbne_xVUWDNE3ww4Faw/view?usp=sharing)

In this demo you can see me pressing tab to toggle the cursor between the file list and the diff pane, using the next and prev bindings in the diff pane to move between hunks, use the next and prev bindings in the file list to move between files, and various changes which make it easy to stage a bunch of hunks quickly simply by pressing s in the diff pane. When opening the project diff screen, your curser is put over the first unstaged diff, so you can begin staging quickly; once all hunks in a file have been staged, you automatically jump to the first unstaged diff in the next file. The overall goal is to make it super fast and seamless to stage a bunch of hunks quickly.

## Commits

### feat(ProjectDiffScreen): Add Tab to toggle focus

Add configurable keymap to switch between file list and diff preview. When switching to diff, cursor jumps to first hunk.

### feat(ProjectDiffScreen): Add hunk_alignment setting

Configurable alignment when jumping to hunks: `'top'`, `'center'`, `'bottom'`. Defaults to `'center'` for better context visibility.

### feat(ProjectDiffScreen): Prefer unstaged entries

Focus on changes the user hasn't reviewed yet. Typical workflow: stage some hunks, exit to fix something, then re-enter project diff. Cursor should resume at unstaged changes, not staged ones.

### fix: Simplify header row positioning logic

Previously, `configure_row()` set `header_win_plot.row` to `row + 1`, and `HeaderElement:mount()` compensated by subtracting 1. Now the logic is straightforward: header stays at original row, content is pushed down.

### feat: Jump to next unstaged file after staging

When staging the last hunk in a file, jump to the next unstaged file rather than staying on the now-staged entry.

### feat: Jump to next staged file after unstaging

When unstaging the last hunk in a file, jump to the next staged file rather than staying on the now-unstaged entry.

### feat(ProjectDiffScreen): Add reset_hunk command

Allows discarding individual hunks from the diff pane. Default keybinding `r`, `buffer_reset` moved to `R`.

### feat(keymap): Add nowait to buffer-local keymaps

Without `nowait`, single-key bindings like `d` can feel sluggish if the user has operator-pending mappings. Vim waits for potential follow-up keys (`dd`, `dw`, etc.) before executing.

### feat(ProjectDiffScreen): Add next/previous nav

Generalized navigation keybinds (default `J`/`K`):
- In diff pane: navigate between hunks across all files
- In file list: navigate between files (skipping folders)

Both wrap around and jump to first/last hunk when crossing files.

### feat(ProjectDiffScreen): Jump to file position on quit

The diff view is a projection of the file's state. Quitting from the diff pane now jumps to the corresponding file position, keeping context stable.

### feat: Remember entry type across sessions

Store `vgit_last_entry_type` buffer variable on quit so re-opening returns to the same staged/unstaged entry for the file.

### fix: Handle empty hunks in deleted file generators

`generate_unified_deleted` and `generate_split_deleted` crashed when passed empty hunks. Add early return guards matching the regular diff generators.

### fix(ProjectDiffScreen): Stay at next hunk/file after staging

Hunk operations (stage/unstage/reset) stay at the same index position, effectively moving to the next hunk. When a file is fully staged or unstaged, jump to the next file of the same type rather than the first.

### fix(ProjectDiffScreen): Refresh gutter signs on quit

Dispatch sync event to git_buffer_store when exiting to a file, ensuring gutter signs reflect any staging changes made in the screen.

## Omitted commit

This commit might need some more work. So hard to get it right...

<details>

### fix: Content padding for tabline offset in floating windows

When `showtabline > 0`, floating windows with `relative='editor'` don't account for the tabline taking screen space, causing the first line(s) of content to be hidden. The fix prepends empty padding lines to buffer content when the tabline is visible (1 line for file list, 2 for diff pane).

**Before**

"Staged Changes" header missing, can't see line 1 in the diff view

<img width="1689" height="1538" alt="Before" src="https://github.com/user-attachments/assets/8b3fd3f8-d01e-4037-838b-758d1e5fc923" />

**After**

Can see "Staged Changes" header, as well as line 1 in the diff view

<img width="1690" height="1536" alt="After" src="https://github.com/user-attachments/assets/507e3925-a0f3-4af0-bd15-5482d0ab271f" />

</details>