### PR TITLE
fix parsing of git blame output

### DIFF
--- a/lua/vgit/git/GitBlame.lua
+++ b/lua/vgit/git/GitBlame.lua
@@ -13,8 +13,10 @@ function GitBlame:constructor(info)
   }
 
   for i = 2, #info do
-    local blame_info = utils.str.split(info[i], ' ')
-    blame[blame_info[1]] = blame_info[2]
+    local field, value = info[i]:match("^(%S+)%s+(.+)")
+    if field ~= nil then
+      blame[field] = value
+    end
   end
 
   local committed = true


### PR DESCRIPTION
When the output of `git blame` is parsed some of the data is missed. Each line of output from `git blame` is split on spaces, however if the line of output has more than one space then everything after the second space is missed. For example if the author name contains a space:

```
author John Smith
```

The author name in live blame will only show "John", not "John Smith".

This change updates the parsing so that everything after the first whitespace in a line is considered the full value of that field.

The check for `nil` is needed so we properly ignore the last line of `git blame` output, which the text from the line in the file preceded by a tab.