### PR TITLE
fix(loop): schedule debounced callbacks and check closed status

### DIFF
--- a/lua/vgit/core/loop.lua
+++ b/lua/vgit/core/loop.lua
@@ -31,7 +31,11 @@ function loop.debounce(fn, ms)
 
     timer:stop()
     timer:start(ms, 0, function()
-      fn(unpack(argv, 1, argc))
+      vim.schedule(function()
+        if not closed then
+          fn(unpack(argv, 1, argc))
+        end
+      end)
     end)
   end
 


### PR DESCRIPTION
Environment

```bash
nvim –version
NVIM v0.11.6
Build type: Release
LuaJIT 2.1.1772148810
```

Description

When opening the commit UI, the following error occurs:

```
Error executing callback:
…/plenary.nvim/lua/plenary/async/async.lua:18:
The coroutine failed with this message:
vim/_editor.lua:0: E5560: nvim_exec2 must not be called in a fast event context

stack traceback:
[C]: in function ‘error’
…/plenary/async/async.lua:18: in function ‘callback_or_next’
…/plenary/async/async.lua:45: in function ‘step’
…/plenary/async/async.lua:48: in function ‘execute’
…/plenary/async/async.lua:118: in function ‘fn’
…/vgit.nvim/lua/vgit/core/loop.lua:34: in function <…>
```

The error is reproducible consistently on NVIM v0.11.6.

Analysis

The issue appears to be caused by calling vim.cmd() (which internally uses nvim_exec2) inside a libuv timer callback.

In loop.debounce:

```lua
function loop.debounce(fn, ms)
  local timer = vim.loop.new_timer()
  local closed = false

  local debounced = function(...)
    if closed then return end
    local argv = { ... }
    local argc = select('#', ...)

    timer:stop()
    timer:start(ms, 0, function()
      fn(unpack(argv, 1, argc))  -- here
    end)
  end

  -- Store cleanup function in registry keyed by the debounced function
  debounced_registry[debounced] = function()
    if not closed and timer and not timer:is_closing() then
      timer:stop()
      timer:close()
      closed = true
      timer = nil
    end
  end

  return debounced
end

```

Since vim.loop.new_timer() runs in a fast event context, executing editor-modifying APIs inside fn() can trigger:

```
E5560: nvim_exec2 must not be called in a fast event context
```

This behavior appears stricter in Neovim >= 0.9 and is reproducible in 0.11.6.